### PR TITLE
fix: don't generate copy rules if used as module

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -126,7 +126,9 @@ def generate_copy_rules(output_spec):
     exec(compile("\n".join(rulestrings), "copy_result_files", "exec"), workflow.globals)
 
 
-generate_copy_rules(output_spec)
+if len(workflow.modules) == 0:
+    # Only generate copy-rules if the workflow is executed directly.
+    generate_copy_rules(output_spec)
 
 
 def get_cnv_callers(tc_method):


### PR DESCRIPTION
If a hydra-genetics workflow using the copy-rules for the final results imports a module that also does this, there will be ambiguous rules since both read from the same output file specification, at least if they use the same config. This PR addresses this by checking if there are any modules loaded. If that is the case, then it is not likely that it is being run as a standalone workflow, and the copy-rules should not be generated.

This should probably also be added to the hydra-genetics pipeline template, if we decide that this is a stable enough solution. I was simply looking around at what variables I could possibly use for determining whether a workflow is run directly or being used as a module, and this was the best I could find from a quick investigation. If anyone has a better solution, I welcome it!