### PR TITLE
fix: correct errors introduced by prettier

### DIFF
--- a/config/cnv_report_template/index.html
+++ b/config/cnv_report_template/index.html
@@ -91,13 +91,9 @@
     <script>
       let cnvData = {{ json | trim | indent(width=8) }};
     </script>
+    <!-- prettier-ignore -->
     <script>
-      {
-        {
-          js | indent((width = 8));
-        }
-      }
+      {{ js | indent(width = 8) }}
     </script>
   </body>
-  <html></html>
 </html>


### PR DESCRIPTION
Using prettier to format HTML with jinja2 delimiters sometimes results in unfortunate formatting. This PR addresses this by adding a comment for prettier to ignore these parts. Ironically, it is not very pretty, but for now I think this is the easiest solution while still being able to keep the formatting consistent.