### PR TITLE
feat: limit maximum zoom in chromosome plot

### DIFF
--- a/config/cnv_report_template/04-main.js
+++ b/config/cnv_report_template/04-main.js
@@ -51,11 +51,59 @@ const resultsTable = new ResultsTable(d3.select("#cnv-table"), {
   filter: d3.select("#table-filter-toggle").node().checked,
 });
 
+const messageModal = document.querySelector("dialog");
+messageModal.addEventListener("click", (e) => {
+  const modalDimensions = messageModal.getBoundingClientRect();
+  if (
+    e.clientX < modalDimensions.left ||
+    e.clientX > modalDimensions.right ||
+    e.clientY < modalDimensions.top ||
+    e.clientY > modalDimensions.bottom
+  ) {
+    messageModal.close();
+  }
+});
+
+document.querySelector("dialog button.close").addEventListener("click", (e) => {
+  e.currentTarget.parentNode.close();
+});
+
+function setModalMessage(msg, className) {
+  let message = document.createElement("p");
+  const messageText = document.createTextNode(msg);
+
+  let icon = document.createElement("i");
+
+  if (className === "error") {
+    icon.className = "fa-solid fa-circle-exclamation";
+  } else if (className === "warning") {
+    icon.className = "fa-solid fa-triangle-exclamation";
+  } else if (className === "info") {
+    icon.className = "fa-solid fa-circle-info";
+  }
+
+  message.appendChild(icon);
+  message.appendChild(messageText);
+
+  messageModal.className = className ? className : "";
+  messageModal.firstChild?.remove();
+  messageModal.prepend(message);
+}
+
 chromosomePlot.addEventListener("zoom", (e) => {
   d3.selectAll(".data-range-warning").classed(
     "hidden",
     !e.detail.dataOutsideRange
   );
+});
+
+chromosomePlot.addEventListener("max-zoom-reached", () => {
+  setModalMessage(
+    "Trying to zoom in too far. " +
+      `Current lower limit is ${chromosomePlot.minZoomRange} bp.`,
+    "error"
+  );
+  messageModal.showModal();
 });
 
 genomePlot.addEventListener("chromosome-change", (e) => {

--- a/config/cnv_report_template/index.html
+++ b/config/cnv_report_template/index.html
@@ -50,6 +50,9 @@
               ></i>
             </div>
             <svg id="chromosome-view"></svg>
+            <dialog id="chromosome-view-dialog">
+              <button class="close"><i class="fa-solid fa-x"></i></button>
+            </dialog>
           </section>
         </div>
 

--- a/config/cnv_report_template/style.css
+++ b/config/cnv_report_template/style.css
@@ -8,6 +8,51 @@ header {
   margin: 3em 0;
 }
 
+dialog {
+  user-select: none;
+}
+
+dialog button.close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 1rem;
+  width: 1rem;
+  overflow: hidden;
+  font-size: 0.5rem;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+dialog p i {
+  margin-right: 0.5em;
+}
+
+dialog.error::backdrop {
+  background-color: #b2000422;
+}
+
+dialog.error p i {
+  color: #b20004;
+}
+
+dialog.warning::backdrop {
+  background-color: #ffa50022;
+}
+
+dialog.warning p i {
+  color: #ffa500;
+}
+
+dialog.info::backdrop {
+  background-color: #2a487d22;
+}
+
+dialog.info p i {
+  color: #2a487d;
+}
+
 .app-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This PR adds a limitation to how far into the chromosome plot a user can zoom (currently 20 bp). When zooming, the colour of the zoom area is tinted red if the interval is under the minimum. If the zoom action is completed in this state, a modal pops up to inform the user. This can be dismissed by clicking outside of the modal, clicking the x in the corner, or by pressing <kbd>Esc</kbd>.

![zoom-limit](https://github.com/hydra-genetics/reports/assets/2573608/d78ae6f0-f575-4f80-b302-ae5c203efebd)