### PR TITLE
fix: optimise transitions in plots

### DIFF
--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -699,44 +699,51 @@ class ChromosomePlot extends EventTarget {
   #drawGridLines() {
     this.#lrGrid
       .selectAll(".gridline")
-      .data(this.ratioYScale.ticks(), (d) => d)
+      .data(this.ratioYScale.ticks(5), (d) => d)
       .join(
-        (enter) =>
+        (enter) => {
           enter
             .append("line")
             .attr("class", "gridline")
             .attr("x1", 0)
-            .attr("x2", this.xScale(this.length))
+            .attr("x2", 0)
             .attr("y1", (d) => this.ratioYScale(d))
-            .attr("y2", (d) => this.ratioYScale(d)),
-        (update) =>
+            .attr("y2", (d) => this.ratioYScale(d))
+            .call((line) =>
+              line.transition().duration(800).attr("x2", this.xScale.range()[1])
+            );
+        },
+        (update) => {
           update
             .transition()
             .duration(this.animationDuration)
             .attr("y1", (d) => this.ratioYScale(d))
-            .attr("y2", (d) => this.ratioYScale(d)),
-        (exit) => exit.remove()
+            .attr("y2", (d) => this.ratioYScale(d))
+            .transition()
+            .duration(800)
+            .attr("x1", this.xScale.range()[0])
+            .attr("x2", this.xScale.range()[1]);
+        },
+        (exit) => {
+          exit
+            .transition()
+            .duration(800)
+            .attr("x1", this.xScale.range()[1])
+            .remove();
+        }
       );
 
     this.#vafGrid
       .selectAll(".gridline")
-      .data(this.vafYScale.ticks(), (d) => d)
-      .join(
-        (enter) =>
-          enter
-            .append("line")
-            .attr("class", "gridline")
-            .attr("x1", 0)
-            .attr("x2", this.xScale(this.length))
-            .attr("y1", (d) => this.vafYScale(d))
-            .attr("y2", (d) => this.vafYScale(d)),
-        (update) =>
-          update
-            .transition()
-            .duration(this.animationDuration)
-            .attr("y1", (d) => this.vafYScale(d))
-            .attr("y2", (d) => this.vafYScale(d)),
-        (exit) => exit.remove()
+      .data(this.vafYScale.ticks(5), (d) => d)
+      .join((enter) =>
+        enter
+          .append("line")
+          .attr("class", "gridline")
+          .attr("x1", 0)
+          .attr("x2", this.xScale(this.length))
+          .attr("y1", (d) => this.vafYScale(d))
+          .attr("y2", (d) => this.vafYScale(d))
       );
   }
 

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -155,6 +155,7 @@ class ChromosomePlot extends EventTarget {
   set data(data) {
     this.#data = data;
     this.resetZoom();
+    this.#drawAxes();
     this.update();
   }
 
@@ -590,6 +591,7 @@ class ChromosomePlot extends EventTarget {
   }
 
   #drawAxes() {
+    this.svg.select(".x-axis").remove();
     this.svg
       .append("g")
       .attr(
@@ -597,11 +599,17 @@ class ChromosomePlot extends EventTarget {
         `translate(${this.margin.left},${this.height - this.margin.bottom})`
       )
       .attr("class", "x-axis")
+      .transition()
+      .duration(this.animationDuration)
       .call(this.xAxis);
+
+    this.svg.selectAll(".y-axis").remove();
     this.svg
       .append("g")
       .attr("transform", `translate(${this.margin.left},${this.margin.top})`)
       .attr("class", "y-axis")
+      .transition()
+      .duration(this.animationDuration)
       .call(this.ratioYAxis);
     this.svg
       .append("g")
@@ -612,6 +620,8 @@ class ChromosomePlot extends EventTarget {
         })`
       )
       .attr("class", "y-axis")
+      .transition()
+      .duration(this.animationDuration)
       .call(this.vafYAxis);
   }
 

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -152,10 +152,21 @@ class ChromosomePlot extends EventTarget {
     return this.#data;
   }
 
-  set data(data) {
-    this.#data = data;
-    this.resetZoom();
-    this.#drawAxes();
+  setData(data, start, end) {
+    const prevChromosome = this.#data.chromosome;
+
+    if (data && data.chromosome !== prevChromosome) {
+      this.#data = data;
+      if (!start && !end) {
+        this.resetZoom();
+      }
+      this.#drawAxes();
+    }
+
+    if (start || end) {
+      this.zoomTo(start, end);
+    }
+
     this.update();
   }
 
@@ -685,6 +696,7 @@ class ChromosomePlot extends EventTarget {
               return;
             }
             this.zoomTo(this.xScale.invert(xMin), this.xScale.invert(xMax));
+            this.update();
           })
       )
       .on("click", () => {
@@ -692,6 +704,7 @@ class ChromosomePlot extends EventTarget {
         if (xMax - xMin !== this.length) {
           // Only reset if something actually changed
           this.resetZoom();
+          this.update();
         }
       });
   }
@@ -854,12 +867,12 @@ class ChromosomePlot extends EventTarget {
       return this;
     }
     this.zoomRange = [start, end];
-    return this.update();
+    this.xScale.domain(this.zoomRange);
   }
 
   resetZoom() {
     this.zoomRange = [0, this.length];
-    return this.update();
+    this.xScale.domain(this.zoomRange);
   }
 
   update() {

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -509,98 +509,123 @@ class ChromosomePlot extends EventTarget {
   #plotAnnotations() {
     this.#plotArea
       .selectAll(".annotation")
-      .attr("clip-path", "url(#annotation-clip)")
-      .data(this.#data.annotations, (d) => [
-        this.#data.chromosome,
-        d.name,
-        d.start,
-        d.end,
-      ])
+      .data(this.#data.annotations, (d) => [d.name, d.start, d.end])
       .join(
         (enter) => {
-          let annotation_group = enter.append("g").attr("class", "annotation");
-          annotation_group
-            .append("rect")
-            .attr("class", "annotation-marker")
-            .attr("x", (d) => this.xScale(d.start))
-            .attr("width", (d) => this.xScale(d.end) - this.xScale(d.start))
-            .attr("height", this.height - this.margin.top - this.margin.bottom)
-            .attr("stroke", "#000")
-            .attr("stroke-width", 0.5)
-            .attr("fill", "#333")
-            .attr("fill-opacity", 0)
-            .attr("pointer-events", "none")
-            .call((enter) => enter.transition().attr("fill-opacity", 0.05));
-          annotation_group
-            .append("rect")
-            .attr("class", "annotation-label-background")
-            .attr("x", (d) => {
-              let [labelWidth, _] = getTextDimensions(d.name, "0.8rem");
-              return (
-                this.xScale(d.start + (d.end - d.start) / 2) -
-                labelWidth / 2 -
-                5
-              );
-            })
-            .attr("y", (d) => {
-              let [_, labelHeight] = getTextDimensions(d.name, "0.8rem");
-              return (
-                this.plotHeight + this.margin.between / 2 - labelHeight / 2 - 2
-              );
-            })
-            .attr("width", (d) => getTextDimensions(d.name, "0.8rem")[0] + 10)
-            .attr("height", (d) => getTextDimensions(d.name, "0.8rem")[1] + 4)
-            .attr("fill", "#EEE")
-            .attr("rx", 4);
-          annotation_group
-            .append("text")
-            .attr("class", "annotation-label")
-            .text((d) => d.name)
-            .attr("x", (d) => this.xScale(d.start + (d.end - d.start) / 2))
-            .attr("y", this.plotHeight + this.margin.between / 2)
-            .attr("text-anchor", "middle")
-            .attr("dominant-baseline", "central");
-          return annotation_group;
+          return enter
+            .append("g")
+            .attr("class", "annotation")
+            .attr("clip-path", "url(#annotation-clip)")
+            .attr("opacity", 0)
+            .call((enter) =>
+              enter
+                .append("rect")
+                .attr("class", "annotation-marker")
+                .attr("x", (d) => this.xScale(d.start))
+                .attr("width", (d) => this.xScale(d.end) - this.xScale(d.start))
+                .attr(
+                  "height",
+                  this.height - this.margin.top - this.margin.bottom
+                )
+                .attr("stroke", "#000")
+                .attr("stroke-width", 0.5)
+                .attr("fill", "#333")
+                .attr("fill-opacity", 0.05)
+                .attr("pointer-events", "none")
+            )
+            .call((enter) =>
+              enter
+                .append("rect")
+                .attr("class", "annotation-label-background")
+                .attr("x", (d) => {
+                  let [labelWidth, _] = getTextDimensions(d.name, "0.8rem");
+                  return (
+                    this.xScale(d.start + (d.end - d.start) / 2) -
+                    labelWidth / 2 -
+                    5
+                  );
+                })
+                .attr("y", (d) => {
+                  let [_, labelHeight] = getTextDimensions(d.name, "0.8rem");
+                  return (
+                    this.plotHeight +
+                    this.margin.between / 2 -
+                    labelHeight / 2 -
+                    2
+                  );
+                })
+                .attr(
+                  "width",
+                  (d) => getTextDimensions(d.name, "0.8rem")[0] + 10
+                )
+                .attr(
+                  "height",
+                  (d) => getTextDimensions(d.name, "0.8rem")[1] + 4
+                )
+                .attr("fill", "#EEE")
+                .attr("rx", 4)
+            )
+            .call((enter) =>
+              enter
+                .append("text")
+                .attr("class", "annotation-label")
+                .text((d) => d.name)
+                .attr("x", (d) => this.xScale(d.start + (d.end - d.start) / 2))
+                .attr("y", this.plotHeight + this.margin.between / 2)
+                .attr("text-anchor", "middle")
+                .attr("dominant-baseline", "central")
+            )
+            .call((enter) =>
+              enter
+                .transition()
+                .duration(this.animationDuration)
+                .attr("opacity", 1)
+            );
         },
-        (update) => {
-          update.selectAll(".annotation-label").call((update) =>
-            update
-              .transition()
-              .duration(this.animationDuration)
-              .attr("x", (d) => this.xScale(d.start + (d.end - d.start) / 2))
-          );
-          update.selectAll(".annotation-label-background").call((update) =>
-            update
-              .transition()
-              .duration(this.animationDuration)
-              .attr("x", (d) => {
-                let [labelWidth, _] = getTextDimensions(d.name, "0.8rem");
-                return (
-                  this.xScale(d.start + (d.end - d.start) / 2) -
-                  labelWidth / 2 -
-                  5
-                );
-              })
-          );
+        (update) =>
           update
-            .selectAll(".annotation-marker")
-            .attr("fill-opacity", 0.05)
             .call((update) =>
               update
+                .selectAll(".annotation-label")
+                .transition()
+                .duration(this.animationDuration)
+                .attr("x", (d) => this.xScale(d.start + (d.end - d.start) / 2))
+            )
+            .call((update) =>
+              update
+                .selectAll(".annotation-label-background")
+                .transition()
+                .duration(this.animationDuration)
+                .attr("x", (d) => {
+                  let [labelWidth, _] = getTextDimensions(d.name, "0.8rem");
+                  return (
+                    this.xScale(d.start + (d.end - d.start) / 2) -
+                    labelWidth / 2 -
+                    5
+                  );
+                })
+            )
+            .call((update) =>
+              update
+                .selectAll(".annotation-marker")
                 .transition()
                 .duration(this.animationDuration)
                 .attr("x", (d) => this.xScale(d.start))
                 .attr("width", (d) => this.xScale(d.end) - this.xScale(d.start))
-            );
-          return update;
-        },
-        (exit) =>
-          exit
+            )
+            .call((update) =>
+              update
+                .transition()
+                .duration(this.animationDuration)
+                .attr("opacity", 1)
+            ),
+        (exit) => {
+          return exit
             .transition()
             .duration(this.animationDuration)
-            .attr("fill-opacity", 0)
-            .attr("stroke-opacity", 0)
-            .remove()
+            .attr("opacity", 0)
+            .remove();
+        }
       );
   }
 

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -796,14 +796,13 @@ class ChromosomePlot extends EventTarget {
       }
     }
 
-    const padding = (yMax - yMin) * 0.05;
-
     if (this.fitToData) {
       this.dispatchEvent(
         new CustomEvent("zoom", {
           detail: { dataOutsideRange: false },
         })
       );
+      const padding = (yMax - yMin) * 0.05;
       this.ratioYScale.domain([yMin - padding, yMax + padding]);
     } else {
       this.dispatchEvent(
@@ -811,6 +810,7 @@ class ChromosomePlot extends EventTarget {
           detail: { dataOutsideRange: yMin < staticYMin || yMax > staticYMax },
         })
       );
+      const padding = (staticYMax - staticYMin) * 0.05;
       this.ratioYScale.domain([staticYMin - padding, staticYMax + padding]);
     }
 

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -827,12 +827,13 @@ class ChromosomePlot extends EventTarget {
       .duration(this.animationDuration)
       .call(this.ratioYAxis);
 
+    this.svg.selectAll(".gridline").remove();
     this.svg
-      .selectAll(".tick")
+      .selectAll(".y-axis .tick")
       .lower()
       .append("line")
       .attr("class", "gridline")
-      .attr("x2", this.width);
+      .attr("x2", this.xScale.range()[1]);
 
     this.svg.select(".x-label").text(this.#data.label);
   }

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -422,6 +422,7 @@ class ChromosomePlot extends EventTarget {
               .duration(this.animationDuration)
               .attr("cx", (d) => this.xScale(d.start))
               .attr("cy", (d) => this.ratioYScale(d.log2))
+              .attr("fill-opacity", 0.3)
           ),
         (exit) => exit.transition().attr("fill-opacity", 0).remove()
       );
@@ -455,6 +456,7 @@ class ChromosomePlot extends EventTarget {
             update
               .transition()
               .duration(this.animationDuration)
+              .attr("stroke-opacity", 1)
               .attr(
                 "d",
                 (d) =>
@@ -493,6 +495,7 @@ class ChromosomePlot extends EventTarget {
               .transition()
               .duration(this.animationDuration)
               .attr("cx", (d) => this.xScale(d.pos))
+              .attr("fill-opacity", 0.3)
           ),
         (exit) =>
           exit

--- a/config/cnv_report_template/01-chromosome-plot.js
+++ b/config/cnv_report_template/01-chromosome-plot.js
@@ -154,7 +154,8 @@ class ChromosomePlot extends EventTarget {
 
   set data(data) {
     this.#data = data;
-    return this.update();
+    this.resetZoom();
+    this.update();
   }
 
   get length() {

--- a/config/cnv_report_template/02-genome-plot.js
+++ b/config/cnv_report_template/02-genome-plot.js
@@ -429,12 +429,21 @@ class GenomePlot extends EventTarget {
       );
   }
 
-  selectChromosome(chromosome) {
+  selectChromosome(chromosome, start, end) {
     const previousChromosomeIndex = this.#selectedChromosome;
     const selectedChromosomeIndex = this.#data.findIndex(
       (d) => d.chromosome === chromosome
     );
     if (previousChromosomeIndex === selectedChromosomeIndex) {
+      this.dispatchEvent(
+        new CustomEvent("chromosome-zoom", {
+          detail: {
+            chromosome: this.#selectedChromosome,
+            start: start,
+            end: end,
+          },
+        })
+      );
       return;
     }
     this.#selectedChromosome = selectedChromosomeIndex;
@@ -444,7 +453,11 @@ class GenomePlot extends EventTarget {
       .classed("selected", true);
     this.dispatchEvent(
       new CustomEvent("chromosome-change", {
-        detail: { chromosome: this.#selectedChromosome },
+        detail: {
+          chromosome: this.#selectedChromosome,
+          start: start,
+          end: end,
+        },
       })
     );
   }

--- a/config/cnv_report_template/04-main.js
+++ b/config/cnv_report_template/04-main.js
@@ -108,7 +108,6 @@ chromosomePlot.addEventListener("max-zoom-reached", () => {
 
 genomePlot.addEventListener("chromosome-change", (e) => {
   chromosomePlot.data = cnvData[e.detail.chromosome];
-  chromosomePlot.resetZoom();
 });
 
 resultsTable.addEventListener("zoom-to-region", (e) => {

--- a/config/cnv_report_template/04-main.js
+++ b/config/cnv_report_template/04-main.js
@@ -107,12 +107,23 @@ chromosomePlot.addEventListener("max-zoom-reached", () => {
 });
 
 genomePlot.addEventListener("chromosome-change", (e) => {
-  chromosomePlot.data = cnvData[e.detail.chromosome];
+  chromosomePlot.setData(
+    cnvData[e.detail.chromosome],
+    e.detail.start,
+    e.detail.end
+  );
+});
+
+genomePlot.addEventListener("chromosome-zoom", (e) => {
+  chromosomePlot.setData(null, e.detail.start, e.detail.end);
 });
 
 resultsTable.addEventListener("zoom-to-region", (e) => {
-  genomePlot.selectChromosome(e.detail.chromosome);
-  chromosomePlot.zoomTo(e.detail.start, e.detail.start + e.detail.length);
+  genomePlot.selectChromosome(
+    e.detail.chromosome,
+    e.detail.start,
+    e.detail.start + e.detail.length
+  );
 });
 
 d3.select("#table-filter-toggle").on("change", (event) => {

--- a/config/cnv_report_template/style.css
+++ b/config/cnv_report_template/style.css
@@ -92,9 +92,9 @@ svg .segment {
 }
 
 svg .gridline {
-  opacity: 0.25;
-  stroke: black;
-  stroke-width: 0.3px;
+  stroke: #dddddd;
+  stroke-width: 0.5px;
+  shape-rendering: crispEdges;
 }
 
 /* Narrow view */


### PR DESCRIPTION
This PR focuses on improving the various transitions that happen in the plots. The most important fix is a bug where the opacity transition of the points could get interrupted, essentially causing them to be more or less invisible. There was a similar issue for the annotation bands.

Now the grid lines are also more tightly connected to the scale, so transitions work much better than before. As a consequence I managed to get rid of the custom plotting function in favour of something much more simple.

Otherwise it is mostly some performance improvements and fixing of small inconsistencies.