### PR TITLE
feat: add template version check

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,5 +12,8 @@ jobs:
         id: release
         with:
           release-type: simple
-          package-name: reporting
+          package-name: reports
           default-branch: main
+          extra-files:
+            - config/cnv_report_template/00-version.js
+            - workflow/rules/common.smk

--- a/config/cnv_report_template/00-version.js
+++ b/config/cnv_report_template/00-version.js
@@ -1,0 +1,1 @@
+const VERSION = "0.2.0"; // x-release-please-version

--- a/config/cnv_report_template/04-main.js
+++ b/config/cnv_report_template/04-main.js
@@ -16,6 +16,18 @@ const getTextDimensions = function (text, fontSize) {
   return [width, height];
 };
 
+d3.select("#reports-version")
+  .call((p) =>
+    p
+      .select("a")
+      .attr(
+        "href",
+        `https://github.com/hydra-genetics/reports/tree/v${VERSION}`
+      )
+  )
+  .select("span")
+  .text(VERSION);
+
 d3.select("#dataset-picker")
   .selectAll("div")
   .data(cnvData[0].callers)

--- a/config/cnv_report_template/index.html
+++ b/config/cnv_report_template/index.html
@@ -22,6 +22,11 @@
             "N/A" }} ({{ metadata.tc_method }})
           </li>
         </ul>
+        <p class="fix-right" id="reports-version">
+          <small
+            ><a>hydra-genetics/reports v<span></span></a
+          ></small>
+        </p>
       </header>
 
       <div class="app-container">

--- a/config/cnv_report_template/style.css
+++ b/config/cnv_report_template/style.css
@@ -8,6 +8,12 @@ header {
   margin: 3em 0;
 }
 
+header .fix-right {
+  position: absolute;
+  top: 0;
+  right: 1em;
+}
+
 dialog {
   user-select: none;
 }

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,3 +3,34 @@
 The reports module consists of a set of rules for creating various reports of results within the context of Hydra Genetics. Reports included at the moment are:
 
 - [CNV report](/reports/#cnvs)
+
+## How to use the module
+
+Include the module in your Hydra Genetics workflow by loading the module in your Snakefile:
+
+```python
+from hydra_genetics.utils.misc import get_module_snakefile
+
+module reports:
+    snakefile: get_module_snakefile(config, "hydra-genetics/reports", path="workflow/Snakefile", tag="v0.2.0")
+    config: config
+
+use rule * from reports as reports_*
+```
+
+It is recommended that only tagged releases of the module are used, and the reason for this is explained in the section [Template version matching](#template-version-matching) below.
+
+### Copying the template
+
+The template for the reports module is located in the [`config/cnv_report_template`](https://github.com/hydra-genetics/reports/tree/main/config/cnv_report_template) directory. This will not be included when loading the model as described above&mdash;it will have to be copied to the main workflow manually. This can be achieved in many different ways, and one way is to use the helper tool <https://download-directory.github.io> and pass in the Github link to the report template. For example, if you want to download v0.2.0 of the module, the final URL would be <https://download-directory.github.io?url=https://github.com/hydra-genetics/reports/tree/v0.2.0/config/cnv_report_template>
+
+!!! important
+    Make sure that the version of the template matches with the version of the module that is being imported. More on that below.
+
+## Template version matching
+
+When using this module as a part of a larger workflow, the templates that are used need to be copied to that workflow since they will not be picked up by the module system. To prevent that the module itself and the template goes out of sync, there is a check in place to make sure that they are in fact based on the same version. If not, the workflow execution will fail with an error message.
+
+A caveat with this is that are cases where there could be a mismatch even though the version numbers are identical, for example, if the module is loaded from a commit that lies between releases while the template belongs to the release immediately prior to that same commit. This is why it is recommended that specific releases are used. If a commit between releases is needed for some reason, make sure to copy the template for that same commit.
+
+This is a feature that was added in v0.3.0, and the check is not done in versions prior to this.

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -144,6 +144,11 @@ def generate_copy_rules(output_spec):
     exec(compile("\n".join(rulestrings), "copy_result_files", "exec"), workflow.globals)
 
 
+if len(workflow.modules) == 0:
+    # Only generate copy-rules if the workflow is executed directly.
+    generate_copy_rules(output_spec)
+
+
 def get_cnv_callers(tc_method):
     for tcm in config.get("svdb_merge", {}).get("tc_method", []):
         if tcm["name"] == tc_method:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -35,12 +35,17 @@ validate(config, schema="../schemas/resources.schema.yaml")
 # Check that the module version matches the template version
 template_version_file = pathlib.Path(config["cnv_html_report"]["template_dir"], "00-version.js")
 if not template_version_file.exists():
-    raise FileNotFoundError("CNV template version file not found, possible mismatch")
+    raise FileNotFoundError(
+        "CNV template version file not found, possible mismatch, "
+        "see https://hydra-genetics-reports.readthedocs.io/en/latest/intro/#template-version-matching"
+    )
 with open(template_version_file) as f:
     template_version = re.search(r'(?<=").+(?=")', f.read().strip())
     if template_version is None or template_version[0] != MODULE_VERSION:
         raise ValueError(
-            f"CNV template version does not match workflow version: found {template_version[0]}, expected {MODULE_VERSION}, see DOC URL"
+            "CNV template version does not match workflow version: "
+            f"found {template_version[0]}, expected {MODULE_VERSION}, "
+            "see https://hydra-genetics-reports.readthedocs.io/en/latest/intro/#template-version-matching"
         )
 
 ### Read and validate samples file


### PR DESCRIPTION
This PR adds a check to ensure that the module itself and the CNV report template are from the same version. As mentioned in the docs, there is the caveat that when using non-release commits, the version numbers might match even when the template and the module come from different commits. The reason for this is that I'm making use of the release-please action to put the version into the template as well as `common.smk`. Therefore I generally recommend that only proper releases are used.

Another approach that I was exploring was to use a type of introspection where I used the workflow object to get the version based on the tag used when loading the snakefile. I decided to not go this way however since it would only work if you are using a code hosting provider, not if the snakefile was given as a plain string. Also, the version number would still have to be added to the template in a different manner, so the same approach might as well be used for adding it to `common.smk`. The current solution should work regardless of whether the module is included locally, if it is using `hydra_genetics.utils.misc.get_module_snakefile`, or one of the [code hosting provider functions provided by Snakemake](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#code-hosting-providers).

At the moment this is not a general check for every type of report. Since there is only the CNV report in the module at the moment it is a bit difficult to anticipate how this might look for other implementations. When more reports are added, this would have to be revised.

In order to fully test that all the version number placeholders get populated correctly I think we have to wait until we trigger a new release since I cannot see a way of triggering release-please for testing purposes. In other words, we (I) have to pay attention to these details in the next release PR.