### PR TITLE
fix(cnv): bug in checking input keys

### DIFF
--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -52,11 +52,11 @@ def main():
     html_filename = snakemake.output.html
 
     js_files = []
-    if "js_files" in snakemake.input:
+    if "js_files" in snakemake.input.keys():
         js_files = snakemake.input.js_files
 
     css_files = []
-    if "css_files" in snakemake.input:
+    if "css_files" in snakemake.input.keys():
         css_files = snakemake.input.css_files
 
     report = create_report(


### PR DESCRIPTION
Apparently the input is not quite dict-like, so you have to explicitly say that you want to look for item in keys, not just item in dict.