### PR TITLE
docs: detail how to override rules and keep some defaults

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,6 +18,29 @@ module reports:
 use rule * from reports as reports_*
 ```
 
+### Overriding rules
+
+Sometimes it might be required to overload only a certain input for a rule. This is however currently not possible with Snakemake&mdash;every input has to be redefined when overloading the rule. You can however make use of the `workflow` object.
+
+Given the example above, let's say we want to overload the `tc_file` input and the associated `tc` and `tc_method` parameters for the rule `cnv_html_report`, but use the default for everything else, we could do this:
+
+```python
+use rule cnv_html_report from reports as reports_cnv_html_report with:
+    input:
+        json=workflow.get_rule("reports_cnv_html_report").input.json,
+        html_template=workflow.get_rule("reports_cnv_html_report").input.html_template,
+        css_files=workflow.get_rule("reports_cnv_html_report").input.css_files,
+        js_files=workflow.get_rule("reports_cnv_html_report").input.js_files,
+        tc_file="{sample}_{type}.tc.txt",
+    params:
+        include_table=workflow.get_rule("reports_cnv_html_report").params.include_table,
+        include_cytobands=workflow.get_rule("reports_cnv_html_report").params.include_cytobands,
+        tc=lambda wc: open("{sample}_{type}.tc.txt".format(**wc)).read().strip(),
+        tc_method="override",
+```
+
+If wildcards are being used, make sure that those wildcards are also defined in the output section of that particular rule for things to function as expected.
+
 ## Versioning caveat
 
 The module makes use of the release-please Github action, meaning that the templates get tagged with the version number every time a new release is published. This means that only reports generated from the main branch are guaranteed to be 100% accurate when it comes the version. Any commit between releases will have the version of the most recent release associated with it.


### PR DESCRIPTION
When overloading rules it is not possible to only overload parts of a section, e.g. only a part of the input. This became a problem after I changed the way the template is being fetched. I did however find a workaround which involves making use of the workflow object to fetch defaults that should not be overloaded.

I haven't tried building this into the logic since that would likely require a change to the Snakemake codebase. There is an [issue about this](https://github.com/snakemake/snakemake/issues/928) in the Snakemake repo, but it hasn't recieved any attention for the past couple of years, so I assume this is not prioritised.