### PR TITLE
feat: support for adding tsv tables

### DIFF
--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -12,6 +12,9 @@ cnv_html_report:
     - tsv: config/extra_table1.tsv
       name: Extra table
       description: An extra table with some extra information.
+    - tsv: config/extra_table2.tsv
+      name: Another extra table
+      description: Another extra table with some extra extra information.
 
 merge_cnv_json:
   annotations:

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -8,6 +8,10 @@ reference:
 
 cnv_html_report:
   cytobands: true
+  extra_tables:
+    - tsv: config/extra_table1.tsv
+      name: Extra table
+      description: An extra table with some extra information.
 
 merge_cnv_json:
   annotations:

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -9,10 +9,10 @@ reference:
 cnv_html_report:
   cytobands: true
   extra_tables:
-    - tsv: config/extra_table1.tsv
+    - path: config/extra_table1.tsv
       name: Extra table
       description: An extra table with some extra information.
-    - tsv: config/extra_table2.tsv
+    - path: config/extra_table2.tsv
       name: Another extra table
       description: Another extra table with some extra extra information.
 

--- a/.tests/integration/config/extra_table1.tsv
+++ b/.tests/integration/config/extra_table1.tsv
@@ -1,0 +1,6 @@
+column1	column2
+value1.1	value1.2
+value2.1	value2.2
+value3.1	value3.2
+value4.1	value4.2
+value5.1	value5.2

--- a/.tests/integration/config/extra_table2.tsv
+++ b/.tests/integration/config/extra_table2.tsv
@@ -1,0 +1,11 @@
+First column	Second column	Third column	Fourth column
+value1.1	value1.2	value1.3	value1.4
+value2.1	value2.2	value2.3	value2.4
+value3.1	value3.2	value3.3	value3.4
+value4.1	value4.2	value4.3	value4.4
+value5.1	value5.2	value5.3	value5.4
+value6.1	value6.2	value6.3	value6.4
+value7.1	value7.2	value7.3	value7.4
+value8.1	value8.2	value8.3	value8.4
+value9.1	value9.2	value9.3	value9.4
+value10.1	value10.2	value10.3	value10.4

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -28,6 +28,19 @@ There are a couple of things that can be customised using the config file.
 
 The CNV results table contains CNVs that have been called by the pipeline. In order for the table to be included in the final report, `show_table` under [`cnv_html_report`](/softwares/#configuration) has to be `true`. If this is the case, then both `filtered_cnv_vcfs` and `unfiltered_cnv_vcfs` have to be defined under [`merge_cnv_json`](/softwares/#configuration_2).
 
+#### Additional tables
+
+Additional tables can be included in the final report by making use of `extra_tables` under [`cnv_html_report`](/softwares/#configuration). A table should be represented by a tsv file, and the first row will be used as a header for the table. The value of `extra_tables` in the config should be an array of objects, and the objects should look like this:
+
+```yaml
+extra_tables:
+    - name: Extra table
+      description: A description of the table
+      tsv: extra_table.tsv
+```
+
+`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `tsv` is the path to the tsv file from which the table should be created.
+
 #### Cytobands
 
 Cytobands can be represented in the chromosome plot. For these to be included, `cytobands` under [`cnv_html_report`](/softwares/#configuration) has to be `true`, and `cytobands` under [`merge_cnv_json`](/softwares/#configuration_2) should point to a file with cytoband definitions. The format of this file should follow the UCSC cytoband schema ([hg19](https://www.genome.ucsc.edu/cgi-bin/hgTables?db=hg19&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema), [hg38](https://genome.ucsc.edu/cgi-bin/hgTables?db=hg38&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema)). Currently, files for both hg19 and hg38 are included in the [config directory of the repo](https://github.com/hydra-genetics/reports/tree/develop/config).

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -36,10 +36,10 @@ Additional tables can be included in the final report by making use of `extra_ta
 extra_tables:
     - name: Extra table
       description: A description of the table
-      tsv: extra_table.tsv
+      path: extra_table.tsv
 ```
 
-`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `tsv` is the path to the tsv file from which the table should be created.
+`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `path` is the path to the tsv file from which the table should be created.
 
 #### Cytobands
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 drmaa==0.7.9
 hydra-genetics==1.3.0
 pandas>=1.3.1
+pulp<2.8.0
 singularity==3.0.0
 snakemake>=7.8.3,<8
 tabulate<0.9.0

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -21,7 +21,7 @@ rule cnv_html_report:
             workflow.source_path("../templates/cnv_html_report/style.css"),
         ],
         tc_file=get_tc_file,
-        extra_table_files=[t["tsv"] for t in config.get("cnv_html_report", {}).get("extra_tables", [])],
+        extra_table_files=[t["path"] for t in config.get("cnv_html_report", {}).get("extra_tables", [])],
     output:
         html=temp("reports/cnv_html_report/{sample}_{type}.{tc_method}.cnv_report.html"),
     params:

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -21,10 +21,12 @@ rule cnv_html_report:
             workflow.source_path("../templates/cnv_html_report/style.css"),
         ],
         tc_file=get_tc_file,
+        extra_table_files=[t["tsv"] for t in config.get("cnv_html_report", {}).get("extra_tables", [])],
     output:
         html=temp("reports/cnv_html_report/{sample}_{type}.{tc_method}.cnv_report.html"),
     params:
         include_table=config.get("cnv_html_report", {}).get("show_table", True),
+        extra_tables=config.get("cnv_html_report", {}).get("extra_tables", []),
         tc=get_tc,
         tc_method=lambda wildcards: wildcards.tc_method,
         include_cytobands=config.get("cnv_html_report", {}).get("cytobands", False),

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -48,6 +48,32 @@ properties:
           Whether or not to display a table of called CNVs in the report. If
           this is true, then the attributes `filtered_cnv_vcfs` and
           `unfiltered_cnv_vcfs` under `merge_cnv_json` are required.
+      extra_tables:
+        type: array
+        description: >
+          Additional tables that should be added to the report. The tables will
+          be based on the columns of the file listed, and column names are
+          required and assumed to be present.
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: >
+                The name of the table.
+            tsv:
+              type: string
+              format: uri-reference
+              description: >
+                Path to a TSV file representing the table to be added. Column
+                names are required and assumed to be present.
+            description:
+              type: string
+              description: >
+                A description of the table.
+          required:
+            - name
+            - tsv
     required:
       - show_table
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -52,7 +52,7 @@ properties:
         type: array
         description: >
           Additional tables that should be added to the report. The tables will
-          be based on the columns of the file listed, and column names are
+          be based on the columns of the TSV file listed, and column names are
           required and assumed to be present.
         items:
           type: object
@@ -61,7 +61,7 @@ properties:
               type: string
               description: >
                 The name of the table.
-            tsv:
+            path:
               type: string
               format: uri-reference
               description: >
@@ -73,7 +73,7 @@ properties:
                 A description of the table.
           required:
             - name
-            - tsv
+            - path
     required:
       - show_table
 

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -10,7 +10,7 @@ def get_sample_name(filename):
 
 
 def parse_table(table_def):
-    with open(table_def["tsv"]) as f:
+    with open(table_def["path"]) as f:
         table_data = list(csv.DictReader(f, delimiter="\t"))
 
     return {

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -1,3 +1,4 @@
+import csv
 from jinja2 import Template
 from pathlib import Path
 import sys
@@ -8,7 +9,19 @@ def get_sample_name(filename):
     return Path(filename).name.split(".")[0]
 
 
-def create_report(template_filename, json_filename, css_files, js_files, show_table, tc, tc_method):
+def parse_table(table_def):
+    with open(table_def["tsv"]) as f:
+        table_data = list(csv.DictReader(f, delimiter="\t"))
+
+    return {
+        "name": table_def.get("name", ""),
+        "description": table_def.get("description", ""),
+        "header": list(table_data[0].keys()),
+        "data": table_data,
+    }
+
+
+def create_report(template_filename, json_filename, css_files, js_files, show_table, extra_tables, tc, tc_method):
     with open(template_filename) as f:
         template = Template(source=f.read())
 
@@ -30,6 +43,7 @@ def create_report(template_filename, json_filename, css_files, js_files, show_ta
             json=json_string,
             css=css_string,
             js=js_string,
+            extra_tables=extra_tables,
             metadata=dict(
                 date=time.strftime("%Y-%m-%d %H:%M", time.localtime()),
                 sample=get_sample_name(json_filename),
@@ -50,6 +64,7 @@ def main():
     json_filename = snakemake.input.json
     html_template = Path(snakemake.input.html_template)
     html_filename = snakemake.output.html
+    extra_tables_def = snakemake.params.extra_tables
 
     js_files = []
     if "js_files" in snakemake.input.keys():
@@ -59,12 +74,15 @@ def main():
     if "css_files" in snakemake.input.keys():
         css_files = snakemake.input.css_files
 
+    extra_tables = [parse_table(t) for t in extra_tables_def]
+
     report = create_report(
         html_template,
         json_filename,
         css_files,
         js_files,
         snakemake.params.include_table,
+        extra_tables,
         snakemake.params.tc,
         snakemake.params.tc_method,
     )

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -100,6 +100,35 @@
           </section>
         </div>
         {% endif %}
+
+        {% if extra_tables | length > 0 %}
+        <div class="table-container">
+          <h2>Additional tables</h2>
+
+          {% for table in extra_tables %}
+          <h3>{{ table.name }}</h3>
+          <p>{{ table.description }}</p>
+          <table id="extra-table-{{ loop.index }}">
+            <thead>
+              <tr>
+                {% for k in table.header %}
+                <th>{{ k }}</th>
+                {% endfor %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in table.data %}
+              <tr>
+                {% for h in table.header %}
+                <td>{{ row[h] }}</td>
+                {% endfor %}
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endfor %}
+        </div>
+        {% endif %}
       </div>
     </div>
     <script>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -72,8 +72,10 @@
           </section>
         </div>
 
-        {% if metadata.show_table %}
+        {% if metadata.show_table or extra_tables | length > 0 %}
         <div class="table-container">
+        {% endif %}
+        {% if metadata.show_table %}
           <section>
             <h2>Results table</h2>
             <p class="no-print">
@@ -98,35 +100,39 @@
             >
             <table id="cnv-table"></table>
           </section>
-        </div>
         {% endif %}
 
         {% if extra_tables | length > 0 %}
-        <div class="table-container">
-          <h2>Additional tables</h2>
+          <section>
+            <h2>Additional tables</h2>
 
-          {% for table in extra_tables %}
-          <h3>{{ table.name }}</h3>
-          <p>{{ table.description }}</p>
-          <table id="extra-table-{{ loop.index }}">
-            <thead>
-              <tr>
-                {% for k in table.header %}
-                <th>{{ k }}</th>
-                {% endfor %}
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in table.data %}
-              <tr>
-                {% for h in table.header %}
-                <td>{{ row[h] }}</td>
-                {% endfor %}
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endfor %}
+            {% for table in extra_tables %}
+            <section>
+              <h3>{{ table.name }}</h3>
+              <p>{{ table.description }}</p>
+              <table id="extra-table-{{ loop.index }}">
+                <thead>
+                  <tr>
+                    {% for k in table.header %}
+                    <th>{{ k }}</th>
+                    {% endfor %}
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in table.data %}
+                  <tr>
+                    {% for h in table.header %}
+                    <td>{{ row[h] }}</td>
+                    {% endfor %}
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </section>
+            {% endfor %}
+          </section>
+        {% endif %}
+        {% if metadata.show_table or extra_tables | length > 0 %} 
         </div>
         {% endif %}
       </div>


### PR DESCRIPTION
This PR adds a functionality where a user can attach tables to the report. These are defined by tsv files (and only tsv files at the moment), where the column names are determined by the first line in the file. In addition to the tsv file, the config allows for giving the table a name (required) and a description (optional). The name will be used as a section heading, and the description will be presented in a paragraph before the table.

The tables will be stacked together with the CNV results table (if displayed, otherwise they will take its place) under the heading "Additional tables":

![image](https://github.com/hydra-genetics/reports/assets/2573608/acce50b0-10a1-4488-8510-549831a4a7a8)

Possible improvements to this includes:

- Support for more formats, e.g. csv.
- If there are many tables, maybe show them in a tabbed interface? This cannot be the case for the printed view though, but that should be easy to manage with some CSS media queries.
- Pagination of large tables. Again, this is something that shouldn't be reflected in the printed view.

This PR also addresses the pulp bug that we've seen for other Snakemake repos.