### PR TITLE
feat: support for adding tsv tables (#63)

### DIFF
--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -8,6 +8,13 @@ reference:
 
 cnv_html_report:
   cytobands: true
+  extra_tables:
+    - path: config/extra_table1.tsv
+      name: Extra table
+      description: An extra table with some extra information.
+    - path: config/extra_table2.tsv
+      name: Another extra table
+      description: Another extra table with some extra extra information.
 
 merge_cnv_json:
   annotations:

--- a/.tests/integration/config/extra_table1.tsv
+++ b/.tests/integration/config/extra_table1.tsv
@@ -1,0 +1,6 @@
+column1	column2
+value1.1	value1.2
+value2.1	value2.2
+value3.1	value3.2
+value4.1	value4.2
+value5.1	value5.2

--- a/.tests/integration/config/extra_table2.tsv
+++ b/.tests/integration/config/extra_table2.tsv
@@ -1,0 +1,11 @@
+First column	Second column	Third column	Fourth column
+value1.1	value1.2	value1.3	value1.4
+value2.1	value2.2	value2.3	value2.4
+value3.1	value3.2	value3.3	value3.4
+value4.1	value4.2	value4.3	value4.4
+value5.1	value5.2	value5.3	value5.4
+value6.1	value6.2	value6.3	value6.4
+value7.1	value7.2	value7.3	value7.4
+value8.1	value8.2	value8.3	value8.4
+value9.1	value9.2	value9.3	value9.4
+value10.1	value10.2	value10.3	value10.4

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -28,6 +28,19 @@ There are a couple of things that can be customised using the config file.
 
 The CNV results table contains CNVs that have been called by the pipeline. In order for the table to be included in the final report, `show_table` under [`cnv_html_report`](/softwares/#configuration) has to be `true`. If this is the case, then both `filtered_cnv_vcfs` and `unfiltered_cnv_vcfs` have to be defined under [`merge_cnv_json`](/softwares/#configuration_2).
 
+#### Additional tables
+
+Additional tables can be included in the final report by making use of `extra_tables` under [`cnv_html_report`](/softwares/#configuration). A table should be represented by a tsv file, and the first row will be used as a header for the table. The value of `extra_tables` in the config should be an array of objects, and the objects should look like this:
+
+```yaml
+extra_tables:
+    - name: Extra table
+      description: A description of the table
+      path: extra_table.tsv
+```
+
+`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `path` is the path to the tsv file from which the table should be created.
+
 #### Cytobands
 
 Cytobands can be represented in the chromosome plot. For these to be included, `cytobands` under [`cnv_html_report`](/softwares/#configuration) has to be `true`, and `cytobands` under [`merge_cnv_json`](/softwares/#configuration_2) should point to a file with cytoband definitions. The format of this file should follow the UCSC cytoband schema ([hg19](https://www.genome.ucsc.edu/cgi-bin/hgTables?db=hg19&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema), [hg38](https://genome.ucsc.edu/cgi-bin/hgTables?db=hg38&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema)). Currently, files for both hg19 and hg38 are included in the [config directory of the repo](https://github.com/hydra-genetics/reports/tree/develop/config).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 drmaa==0.7.9
 hydra-genetics==1.3.0
 pandas>=1.3.1
+pulp<2.8.0
 singularity==3.0.0
 snakemake>=7.8.3,<8
 tabulate<0.9.0

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -21,10 +21,12 @@ rule cnv_html_report:
             workflow.source_path("../templates/cnv_html_report/style.css"),
         ],
         tc_file=get_tc_file,
+        extra_table_files=[t["path"] for t in config.get("cnv_html_report", {}).get("extra_tables", [])],
     output:
         html=temp("reports/cnv_html_report/{sample}_{type}.{tc_method}.cnv_report.html"),
     params:
         include_table=config.get("cnv_html_report", {}).get("show_table", True),
+        extra_tables=config.get("cnv_html_report", {}).get("extra_tables", []),
         tc=get_tc,
         tc_method=lambda wildcards: wildcards.tc_method,
         include_cytobands=config.get("cnv_html_report", {}).get("cytobands", False),

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -48,6 +48,32 @@ properties:
           Whether or not to display a table of called CNVs in the report. If
           this is true, then the attributes `filtered_cnv_vcfs` and
           `unfiltered_cnv_vcfs` under `merge_cnv_json` are required.
+      extra_tables:
+        type: array
+        description: >
+          Additional tables that should be added to the report. The tables will
+          be based on the columns of the TSV file listed, and column names are
+          required and assumed to be present.
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: >
+                The name of the table.
+            path:
+              type: string
+              format: uri-reference
+              description: >
+                Path to a TSV file representing the table to be added. Column
+                names are required and assumed to be present.
+            description:
+              type: string
+              description: >
+                A description of the table.
+          required:
+            - name
+            - path
     required:
       - show_table
 

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -72,8 +72,10 @@
           </section>
         </div>
 
-        {% if metadata.show_table %}
+        {% if metadata.show_table or extra_tables | length > 0 %}
         <div class="table-container">
+        {% endif %}
+        {% if metadata.show_table %}
           <section>
             <h2>Results table</h2>
             <p class="no-print">
@@ -98,6 +100,39 @@
             >
             <table id="cnv-table"></table>
           </section>
+        {% endif %}
+
+        {% if extra_tables | length > 0 %}
+          <section>
+            <h2>Additional tables</h2>
+
+            {% for table in extra_tables %}
+            <section>
+              <h3>{{ table.name }}</h3>
+              <p>{{ table.description }}</p>
+              <table id="extra-table-{{ loop.index }}">
+                <thead>
+                  <tr>
+                    {% for k in table.header %}
+                    <th>{{ k }}</th>
+                    {% endfor %}
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in table.data %}
+                  <tr>
+                    {% for h in table.header %}
+                    <td>{{ row[h] }}</td>
+                    {% endfor %}
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </section>
+            {% endfor %}
+          </section>
+        {% endif %}
+        {% if metadata.show_table or extra_tables | length > 0 %} 
         </div>
         {% endif %}
       </div>


### PR DESCRIPTION
* Add extra tables to config

* Add extra tables to report

* Add another table for the integration test

* Some restructuring to make the tables flow nicer

* Describe the additional tables in the documentation

* Change the key in the config from tsv to path

This to make things a bit more general, and to make it a bit easier to introduce support for additional formats in the future.

* fix: pin pulp version

fix: pin pulp to version <2.8.0 for snakemake <8.1.2
