### PR TITLE
fix: allow wildcards in extra_table path

### DIFF
--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.extra_table.tsv
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.extra_table.tsv
@@ -1,0 +1,4 @@
+Wildcards table column 1	Wildcards table column 2
+value 1	value 2
+value 3	value 4
+value 5	value 6

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -20,6 +20,12 @@ cnv_html_report:
       description: >
         The file on which this table is based on has wildcards in
         the filename.
+    - path: config/empty_table.tsv
+      name: An empty table
+      description: >
+        A table that only has a header row, but no data. It should still
+        be presented, but it should at the same time be clear that it is
+        empty, and meant to be so.
 
 merge_cnv_json:
   annotations:

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -15,6 +15,11 @@ cnv_html_report:
     - path: config/extra_table2.tsv
       name: Another extra table
       description: Another extra table with some extra extra information.
+    - path: cnv_sv/svdb_query/{sample}_{type}.extra_table.tsv
+      name: Extra table with wildcards
+      description: >
+        The file on which this table is based on has wildcards in
+        the filename.
 
 merge_cnv_json:
   annotations:

--- a/.tests/integration/config/empty_table.tsv
+++ b/.tests/integration/config/empty_table.tsv
@@ -1,0 +1,1 @@
+Empty table column 1	Empty table column 2

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -41,6 +41,10 @@ extra_tables:
 
 `name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `path` is the path to the tsv file from which the table should be created.
 
+If the table file is completely empty, the execution will fail with an error. If the table is empty, but it has a table row, the table will be presented. It will however have a message clarifying that there is no data in the table.
+
+Wildcards are allowed in `path`, as long as the same wildcards are present in the output file name. By default these wildcards are `sample`, `type` and `tc_method`.
+
 #### Cytobands
 
 Cytobands can be represented in the chromosome plot. For these to be included, `cytobands` under [`cnv_html_report`](/softwares/#configuration) has to be `true`, and `cytobands` under [`merge_cnv_json`](/softwares/#configuration_2) should point to a file with cytoband definitions. The format of this file should follow the UCSC cytoband schema ([hg19](https://www.genome.ucsc.edu/cgi-bin/hgTables?db=hg19&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema), [hg38](https://genome.ucsc.edu/cgi-bin/hgTables?db=hg38&hgta_group=map&hgta_track=cytoBand&hgta_table=cytoBand&hgta_doSchema=describe+table+schema)). Currently, files for both hg19 and hg38 are included in the [config directory of the repo](https://github.com/hydra-genetics/reports/tree/develop/config).

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -39,11 +39,7 @@ extra_tables:
       path: extra_table.tsv
 ```
 
-`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `path` is the path to the tsv file from which the table should be created.
-
-If the table file is completely empty, the execution will fail with an error. If the table is empty, but it has a table row, the table will be presented. It will however have a message clarifying that there is no data in the table.
-
-Wildcards are allowed in `path`, as long as the same wildcards are present in the output file name. By default these wildcards are `sample`, `type` and `tc_method`.
+`name` is the name of the table, and will be used as a section heading. `description` is a description of the table and will be displayed as a single paragraph, and `path` is the path to the tsv file from which the table should be created. If the table file is completely empty, the execution will fail with an error. If the table is empty, but it contains a header, the table will be presented. It will however have a message clarifying that there is no data in the table, and that this is how it is meant to be. Wildcards are allowed in `path`, as long as the same wildcards are present in the output file name. By default these wildcards are `sample`, `type` and `tc_method`.
 
 #### Cytobands
 

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -12,12 +12,17 @@ def get_sample_name(filename):
 def parse_table(table_def):
     tsv_path = table_def["path"].format(**snakemake.wildcards)
     with open(tsv_path) as f:
-        table_data = list(csv.DictReader(f, delimiter="\t"))
+        reader = csv.DictReader(f, delimiter="\t")
+        header = reader.fieldnames
+        table_data = list(reader)
+
+    if len(table_data) == 0 and not header:
+        raise ValueError(f"empty table in {tsv_path}")
 
     return {
         "name": table_def.get("name", ""),
         "description": table_def.get("description", ""),
-        "header": list(table_data[0].keys()),
+        "header": header,
         "data": table_data,
     }
 

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -10,7 +10,8 @@ def get_sample_name(filename):
 
 
 def parse_table(table_def):
-    with open(table_def["path"]) as f:
+    tsv_path = table_def["path"].format(**snakemake.wildcards)
+    with open(tsv_path) as f:
         table_data = list(csv.DictReader(f, delimiter="\t"))
 
     return {

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -119,6 +119,7 @@
                   </tr>
                 </thead>
                 <tbody>
+                  {% if table.data | length > 0 %}
                   {% for row in table.data %}
                   <tr>
                     {% for h in table.header %}
@@ -126,6 +127,13 @@
                     {% endfor %}
                   </tr>
                   {% endfor %}
+                  {% else %}
+                  <tr>
+                    <td colspan="{{ table.header | length }}">
+                      No data available in table
+                    </td>
+                  </tr>
+                  {% endif %}
                 </tbody>
               </table>
             </section>


### PR DESCRIPTION
This PR addresses a couple of issues.

Firstly, wildcards in the extra_table path did not work as expected. This should now be addressed, and any wildcards that are present in the output filename can be used in the table filename. By default these are `sample`, `type` and `tc_method`.

Secondly, if a table was technically empty, but still had the header line, the generation would fail. This PR allows for empty tables as long as the header is defined. Such a table will be presented with a message that there is no data in the table (see screenshot below). The reason for allowing this is that some other rule might generate a file where there simply are no results, and I think this should be reflected in the report. Supplying a completely empty file will still give an error, but now with a much better error message.

![image](https://github.com/hydra-genetics/reports/assets/2573608/2e18e405-c48c-45ad-8c55-966fd60ce7e9)