### PR TITLE
feat(cnv): make log2-ratio baseline more distinct

### DIFF
--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1050,7 +1050,9 @@ class ChromosomePlot extends EventTarget {
       .selectAll(".y-axis .tick")
       .lower()
       .append("line")
-      .attr("class", "gridline")
+      .attr("class", (d) => {
+        return d == 0 ? "gridline baseline" : "gridline";
+      })
       .attr("x2", this.xScale.range()[1]);
 
     this.svg.select(".x-label").text(this.#data.label);

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -325,7 +325,7 @@ class GenomePlot extends EventTarget {
             );
           }
         },
-        function(d) {
+        function (d) {
           if (this.dataset.caller) {
             return [this.dataset.caller, d.start, d.log2, d.mean];
           }
@@ -458,25 +458,26 @@ class GenomePlot extends EventTarget {
         },
         (exit) => {
           if (exit.data()[0]?.mean) {
-            return exit.call((exit) => {
-              exit
-                .selectAll(".variance-rect")
-                .transition()
-                .duration(this.animationDuration)
-                .attr("y", this.ratioYScale.range()[1])
-                .attr("height", 0)
-            })
-            .call((exit) => {
-              exit
-                .selectAll(".mean")
-                .transition()
-                .duration(this.animationDuration)
-                .attr("y1", this.ratioYScale.range()[1])
-                .attr("y2", this.ratioYScale.range()[1])
-            })
-            .transition()
-            .delay(this.animationDuration)
-            .remove();
+            return exit
+              .call((exit) => {
+                exit
+                  .selectAll(".variance-rect")
+                  .transition()
+                  .duration(this.animationDuration)
+                  .attr("y", this.ratioYScale.range()[1])
+                  .attr("height", 0);
+              })
+              .call((exit) => {
+                exit
+                  .selectAll(".mean")
+                  .transition()
+                  .duration(this.animationDuration)
+                  .attr("y1", this.ratioYScale.range()[1])
+                  .attr("y2", this.ratioYScale.range()[1]);
+              })
+              .transition()
+              .delay(this.animationDuration)
+              .remove();
           }
 
           return exit
@@ -498,7 +499,7 @@ class GenomePlot extends EventTarget {
           d.callers[this.#activeCaller].segments.filter(
             (s) => s.end - s.start > this.totalLength / this.width
           ),
-        function(d) {
+        function (d) {
           if (this.dataset.caller) {
             return [this.dataset.caller, d.start, d.end, d.log2];
           }
@@ -538,9 +539,9 @@ class GenomePlot extends EventTarget {
               .attr("d", (d, i, g) => {
                 let j = g[i].parentNode.dataset.index;
                 let xScale = this.xScales[j];
-                return `M${xScale(d.start)} ${this.ratioYScale(d.log2)} L ${xScale(
-                  d.end
-                )} ${this.ratioYScale(d.log2)}`;
+                return `M${xScale(d.start)} ${this.ratioYScale(
+                  d.log2
+                )} L ${xScale(d.end)} ${this.ratioYScale(d.log2)}`;
               });
           }),
         (exit) =>

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -238,7 +238,9 @@ class GenomePlot extends EventTarget {
       )
       .attr("y1", (d) => this.ratioYScale(d))
       .attr("y2", (d) => this.ratioYScale(d))
-      .attr("class", "gridline");
+      .attr("class", (d) => {
+        return d === 0 ? "gridline baseline" : "gridline";
+      });
 
     vafGrid
       .selectAll(".gridline")

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -103,6 +103,11 @@ svg .gridline {
   shape-rendering: crispEdges;
 }
 
+svg .gridline.baseline {
+  stroke: #777777;
+  stroke-width: 1.5px;
+}
+
 /* Narrow view */
 @media screen and (max-width: 600px) {
   .plot-container .x-label,


### PR DESCRIPTION
The purpose of this PR is to make the baseline for the log<sub>2</sub> ratios in the CNV report stand out a little bit better than before. This has been implemented both for the chromosome view and the genome view.

Previously:
![image](https://github.com/user-attachments/assets/a7238a84-a1ef-4042-b074-36d04740faa3)

Now:
![image](https://github.com/user-attachments/assets/91f2174f-e7d3-4698-83f7-8f784b0e8aa0)
