### PR TITLE
feat(cnv): ability to modify log2 ratio baseline

### DIFF
--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -133,31 +133,38 @@ d3.select("#chromosome-show-all-datapoints").on("change", (e) => {
   chromosomePlot.showAllData = e.target.checked;
 });
 
-const baselineOffsetInput = d3.select("#chromosome-baseline-offset");
+const baselineOffsetSlider = d3.select("#chromosome-baseline-offset");
 const currentBaselineOffset = d3.select("#current-baseline-offset");
 const baselineOffsetReset = d3.select("#reset-baseline-offset");
 
-baselineOffsetInput.on("change", (e) => {
-  const dy = e.target.value;
+baselineOffsetSlider.on("change", () => {
+  currentBaselineOffset.node().dispatchEvent(new Event("change"));
+});
+
+baselineOffsetSlider.on("input", (e) => {
+  const dy = parseFloat(e.target.value);
+  const strdy = dy.toLocaleString("en-US", { minimumFractionDigits: 2 });
+  currentBaselineOffset.node().value = strdy;
+});
+
+currentBaselineOffset.on("change", (e) => {
+  const dy = parseFloat(e.target.value);
   baselineOffsetReset.property("disabled", true);
   if (dy != 0) {
     baselineOffsetReset.property("disabled", false);
   }
+  const strdy = dy.toLocaleString("en-US", { minimumFractionDigits: 2 });
+  baselineOffsetSlider.node().value = dy;
+  currentBaselineOffset.node().value = strdy;
   chromosomePlot.setBaselineOffset(dy);
   genomePlot.setBaselineOffset(dy);
 });
 
-baselineOffsetInput.on("input", (e) => {
-  const dy = parseFloat(e.target.value);
-  const strdy = dy.toLocaleString("en-US", { minimumFractionDigits: 1 });
-  currentBaselineOffset.text(strdy);
-});
-
 baselineOffsetReset.on("click", () => {
-  baselineOffsetInput.node().value = 0;
+  baselineOffsetSlider.node().value = 0;
   baselineOffsetReset.property("disabled", true);
-  currentBaselineOffset.text("0.0");
-  baselineOffsetInput.node().dispatchEvent(new Event("change"));
+  currentBaselineOffset.node().value = "0.00";
+  baselineOffsetSlider.node().dispatchEvent(new Event("change"));
 });
 
 d3.selectAll("input[name=dataset]").on("change", (e) => {

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -133,6 +133,31 @@ d3.select("#chromosome-show-all-datapoints").on("change", (e) => {
   chromosomePlot.showAllData = e.target.checked;
 });
 
+const baselineOffsetInput = d3.select("#chromosome-baseline-offset");
+const currentBaselineOffset = d3.select("#current-baseline-offset");
+const baselineOffsetReset = d3.select("#reset-baseline-offset");
+
+baselineOffsetInput.on("change", (e) => {
+  const dy = e.target.value;
+  baselineOffsetReset.property("disabled", true);
+  if (dy != 0) {
+    baselineOffsetReset.property("disabled", false);
+  }
+  chromosomePlot.setBaselineOffset(dy);
+});
+
+baselineOffsetInput.on("input", (e) => {
+  const dy = e.target.value;
+  currentBaselineOffset.text(dy);
+});
+
+baselineOffsetReset.on("click", () => {
+  baselineOffsetInput.node().value = 0;
+  baselineOffsetReset.property("disabled", true);
+  currentBaselineOffset.text(0);
+  baselineOffsetInput.node().dispatchEvent(new Event("change"));
+});
+
 d3.selectAll("input[name=dataset]").on("change", (e) => {
   chromosomePlot.activeCaller = parseInt(e.target.value);
   genomePlot.activeCaller = parseInt(e.target.value);

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -148,14 +148,15 @@ baselineOffsetInput.on("change", (e) => {
 });
 
 baselineOffsetInput.on("input", (e) => {
-  const dy = e.target.value;
-  currentBaselineOffset.text(dy);
+  const dy = parseFloat(e.target.value);
+  const strdy = dy.toLocaleString("en-US", { minimumFractionDigits: 1 });
+  currentBaselineOffset.text(strdy);
 });
 
 baselineOffsetReset.on("click", () => {
   baselineOffsetInput.node().value = 0;
   baselineOffsetReset.property("disabled", true);
-  currentBaselineOffset.text(0);
+  currentBaselineOffset.text("0.0");
   baselineOffsetInput.node().dispatchEvent(new Event("change"));
 });
 

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -148,11 +148,27 @@ baselineOffsetSlider.on("input", (e) => {
 });
 
 currentBaselineOffset.on("change", (e) => {
+  const minDy = e.target.min ? parseFloat(e.target.min) : -2.0;
+  const maxDy = e.target.max ? parseFloat(e.target.max) : 2.0;
   const dy = parseFloat(e.target.value);
+
+  if (dy < minDy || dy > maxDy) {
+    e.target.classList.add("invalid");
+    e.target.title = `Value outside the valid range [${minDy}, ${maxDy}]`;
+    console.error(
+      `baseline offset outside the valid range [${minDy}, ${maxDy}]`
+    );
+    return;
+  }
+
+  e.target.classList.remove("invalid");
+  e.target.title = "";
+
   baselineOffsetReset.property("disabled", true);
   if (dy != 0) {
     baselineOffsetReset.property("disabled", false);
   }
+
   const strdy = dy.toLocaleString("en-US", { minimumFractionDigits: 2 });
   baselineOffsetSlider.node().value = dy;
   currentBaselineOffset.node().value = strdy;

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -144,6 +144,7 @@ baselineOffsetInput.on("change", (e) => {
     baselineOffsetReset.property("disabled", false);
   }
   chromosomePlot.setBaselineOffset(dy);
+  genomePlot.setBaselineOffset(dy);
 });
 
 baselineOffsetInput.on("input", (e) => {

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -71,10 +71,10 @@
                   id="chromosome-baseline-offset"
                   min="-2"
                   max="2"
-                  step="0.1"
+                  step="0.05"
                   value="0"
                 />
-                <span id="current-baseline-offset">0.0</span>
+                <input type="number" min="-2" max="2" step="0.05" id="current-baseline-offset" value="0.00"></input>
                 <button id="reset-baseline-offset" disabled>Reset</button>
               </div>
             </div>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -69,8 +69,8 @@
                 <input
                   type="range"
                   id="chromosome-baseline-offset"
-                  min="-5"
-                  max="5"
+                  min="-2"
+                  max="2"
                   step="0.1"
                   value="0"
                 />

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -64,6 +64,19 @@
                   >Show all data points</label
                 >
               </div>
+              <div>
+                <label for="chromosome-baseline-offset">Baseline offset</label>
+                <input
+                  type="range"
+                  id="chromosome-baseline-offset"
+                  min="-5"
+                  max="5"
+                  step="0.1"
+                  value="0"
+                />
+                <span id="current-baseline-offset">0</span>
+                <button id="reset-baseline-offset" disabled>Reset</button>
+              </div>
             </div>
             <svg id="chromosome-view"></svg>
             <dialog id="chromosome-view-dialog">

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -74,7 +74,7 @@
                   step="0.1"
                   value="0"
                 />
-                <span id="current-baseline-offset">0</span>
+                <span id="current-baseline-offset">0.0</span>
                 <button id="reset-baseline-offset" disabled>Reset</button>
               </div>
             </div>

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -90,9 +90,7 @@ dialog.info p i {
 }
 
 #current-baseline-offset {
-  display: inline-block;
-  width: 1.75rem;
-  text-align: right;
+  width: 3rem;
   margin-right: 0.5rem;
 }
 

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -94,6 +94,10 @@ dialog.info p i {
   margin-right: 0.5rem;
 }
 
+#current-baseline-offset.invalid {
+  background-color: #ff6762;
+}
+
 svg .panel-overlay {
   stroke: forestgreen;
 }

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -89,6 +89,13 @@ dialog.info p i {
   max-width: 60em;
 }
 
+#current-baseline-offset {
+  display: inline-block;
+  width: 1.75rem;
+  text-align: right;
+  margin-right: 0.5rem;
+}
+
 svg .panel-overlay {
   stroke: forestgreen;
 }


### PR DESCRIPTION
This PR makes it possible to adjust the baseline of the log2-ratios in the plots.

![image](https://github.com/user-attachments/assets/df375177-cdda-412f-b1a0-5bf3265e55b4)

The slider goes from -5 to +5 with a step size of 0.1. The reset button sets the offset to zero. Log ratios in the chromosome view and the genome view get updated once the slider is released. I tried having update as you drag it, but performance was pretty bad. With some optimisations of how things are drawn, this could probably be improved, but I'm not sure the effort is worth it.

Here's a small example of it in action:

![baseline_shift_example](https://github.com/user-attachments/assets/f706f382-7168-4b86-916e-bec527e935d2)
