### PR TITLE
feat(cnv): add horizontal cursor for log2 ratio and VAF

### DIFF
--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1228,12 +1228,19 @@ class ChromosomePlot extends EventTarget {
           })
       )
       .on("click", (e) => {
+        isDragging = false;
         const [xMin, xMax] = this.xScale.domain();
         if (xMax - xMin !== this.length) {
           this.resetZoom();
           this.update();
         }
-        positionCursor.set(d3.pointer(e)[0]);
+        const pos = d3.pointer(e);
+        positionCursor.set(pos[0]);
+        if (e.target.parentElement.id === "lr-mousetrap") {
+          ratioCursor.set(pos[1]);
+        } else if (e.target.parentElement.id == "vaf-mousetrap") {
+          vafCursor.set(pos[1]);
+        }
       });
 
     const positionCursor = new XCursor({

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1097,6 +1097,7 @@ class ChromosomePlot extends EventTarget {
   }
 
   initialiseMousetrap() {
+    let isDragging = false;
     const mouseTrap = this.svg
       .append("g")
       .attr("transform", `translate(${this.margin.left},${this.margin.top})`);
@@ -1134,6 +1135,9 @@ class ChromosomePlot extends EventTarget {
       .attr("pointer-events", "all");
 
     mouseTrap.select("#lr-mousetrap").on("mouseenter mousemove", (e) => {
+      if (isDragging) {
+        return;
+      }
       let pos = d3.pointer(e);
       ratioCursor.set(pos[1]);
       positionCursor.set(pos[0]);
@@ -1145,6 +1149,9 @@ class ChromosomePlot extends EventTarget {
     });
 
     mouseTrap.select("#vaf-mousetrap").on("mouseenter mousemove", (e) => {
+      if (isDragging) {
+        return;
+      }
       let pos = d3.pointer(e);
       vafCursor.set(pos[1]);
       positionCursor.set(pos[0]);
@@ -1165,6 +1172,7 @@ class ChromosomePlot extends EventTarget {
         d3
           .drag()
           .on("start", (e) => {
+            isDragging = true;
             zoomLayer
               .append("rect")
               .attr("id", "zoom-region")
@@ -1215,6 +1223,7 @@ class ChromosomePlot extends EventTarget {
               return;
             }
             this.zoomTo(this.xScale.invert(xMin), this.xScale.invert(xMax));
+            isDragging = false;
             this.update();
           })
       )

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1219,11 +1219,11 @@ class ChromosomePlot extends EventTarget {
               this.xScale.range()[1],
               Math.max(e.x, e.subject.x)
             );
+            isDragging = false;
             if (xMax - xMin < 3) {
               return;
             }
             this.zoomTo(this.xScale.invert(xMin), this.xScale.invert(xMax));
-            isDragging = false;
             this.update();
           })
       )

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1176,6 +1176,8 @@ class ChromosomePlot extends EventTarget {
               .attr("stroke-width", 0)
               .attr("fill-opacity", 0.1)
               .attr("pointer-events", "none");
+            ratioCursor.hide();
+            vafCursor.hide();
           })
           .on("drag", (e) => {
             const leftBound = Math.min(e.x, e.subject.x);
@@ -1199,6 +1201,8 @@ class ChromosomePlot extends EventTarget {
             } else {
               zoomRegion.attr("fill", "#333");
             }
+
+            positionCursor.set(e.x);
           })
           .on("end", (e) => {
             zoomLayer.select("#zoom-region").remove();

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -314,6 +314,16 @@ class ChromosomePlot extends EventTarget {
       .attr("pointer-events", "all");
     this.mouseTrap
       .append("g")
+      .attr("transform", `translate(0,${this.plotHeight})`)
+      .attr("id", "zoom-mousetrap")
+      .append("rect")
+      .attr("class", "mousetrap")
+      .attr("width", this.width - this.margin.left - this.margin.right)
+      .attr("height", this.margin.between)
+      .attr("fill", "none")
+      .attr("pointer-events", "all");
+    this.mouseTrap
+      .append("g")
       .attr(
         "transform",
         `translate(0,${this.plotHeight + this.margin.between})`
@@ -329,6 +339,11 @@ class ChromosomePlot extends EventTarget {
     this.mouseTrap.select("#lr-mousetrap").on("mouseenter mousemove", (e) => {
       let pos = d3.pointer(e);
       this.ratioCursor.set(pos[1]);
+      this.positionCursor.set(pos[0]);
+    });
+
+    this.mouseTrap.select("#zoom-mousetrap").on("mouseenter mousemove", (e) => {
+      let pos = d3.pointer(e);
       this.positionCursor.set(pos[0]);
     });
 

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -20,6 +20,7 @@ class YCursor {
       .append("g")
       .lower()
       .attr("class", "cursor")
+      .attr("pointer-events", "none")
       .attr("opacity", this.hidden ? 0 : 1);
 
     this.cursor


### PR DESCRIPTION
This PR adds a horizontal cursor to the chromosome plot where the VAF and the log<sub>2</sub> ratio are presented. In addition to getting more exact values from the figure, it can also be of use when you want to compare distant regions on the same chromosome, or determine whether values drift over a long segment.

In making this work, I had to do some restructuring related to how the mouse events were handled. Now there is a group of elements that I call a mousetrap that catches all the mouse events and handles them accordingly. As a result, the zooming functionality had to be refactored.

The mousetrap is composed of three panels: one for the log<sub>2</sub> ratio plot, one for the VAF plot, and one for the margin between the plots. The panels for the respective plotting areas handle horizontal and vertical cursors, as well as zoom. The panel in the margin between the plots handle only the vertical cursor and the zoom.

![horizontal_cursor](https://github.com/user-attachments/assets/59d08c9c-7c52-4b58-9594-d01b42f73012)

