### PR TITLE
feat(cnv): add secondary axis for copy numbers

### DIFF
--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -10,6 +10,9 @@ class YCursor {
     this.labelHeight =
       this.textHeight + this.labelMargin.top + this.labelMargin.bottom;
     this.yScale = config?.yScale ? config.yScale : null;
+    this.secondaryYScale = config?.secondaryYScale
+      ? config.secondaryYScale
+      : null;
     this.hidden = config?.hidden ? config.hidden : true;
 
     if (this.yScale === null) {
@@ -32,7 +35,7 @@ class YCursor {
 
     this.cursor
       .append("rect")
-      .attr("class", "cursor-label")
+      .attr("class", "cursor-label primary")
       .attr("y", -this.labelHeight)
       .attr("height", this.labelHeight)
       .attr("rx", 3)
@@ -41,10 +44,29 @@ class YCursor {
 
     this.cursor
       .append("text")
+      .attr("class", "primary")
       .attr("x", 5)
       .attr("fill", "black")
       .attr("font-size", this.fontSize)
       .attr("alignment-baseline", "baseline");
+
+    if (this.secondaryYScale !== null) {
+      this.cursor
+        .append("rect")
+        .attr("class", "cursor-label secondary")
+        .attr("y", -this.labelHeight)
+        .attr("height", this.labelHeight)
+        .attr("rx", 3)
+        .attr("stroke", "black")
+        .attr("fill", "white");
+
+      this.cursor
+        .append("text")
+        .attr("class", "secondary")
+        .attr("fill", "black")
+        .attr("font-size", this.fontSize)
+        .attr("alignment-baseline", "baseline");
+    }
   }
 
   show() {
@@ -63,15 +85,43 @@ class YCursor {
     let labelWidth = textWidth + this.labelMargin.left + this.labelMargin.right;
 
     this.cursor.attr("opacity", 1).attr("transform", `translate(0,${y})`);
+
+    if (this.secondaryYScale !== null) {
+      let secondaryLabel = this.secondaryYScale.invert(y).toLocaleString();
+      let secondaryTextWidth = getTextDimensions(
+        secondaryLabel,
+        this.fontSize
+      )[0];
+      let secondaryLabelWidth =
+        secondaryTextWidth + this.labelMargin.left + this.labelMargin.right;
+
+      this.cursor
+        .select(".cursor-label.secondary")
+        .attr("width", secondaryLabelWidth)
+        .attr(
+          "transform",
+          `translate(${this.width + 5}, ${this.labelHeight / 2})`
+        );
+      this.cursor
+        .select("text.secondary")
+        .attr(
+          "transform",
+          `translate(${this.width + 5 + this.labelMargin.left}, ${
+            this.labelHeight / 2 - this.labelMargin.bottom
+          })`
+        )
+        .text(secondaryLabel);
+    }
+
     this.cursor
-      .select(".cursor-label")
+      .select(".cursor-label.primary")
       .attr("width", labelWidth)
       .attr(
         "transform",
         `translate(${-(5 + labelWidth)}, ${this.labelHeight / 2})`
       );
     this.cursor
-      .select("text")
+      .select("text.primary")
       .attr(
         "transform",
         `translate(${-(5 + labelWidth)}, ${
@@ -1278,6 +1328,7 @@ class ChromosomePlot extends EventTarget {
       element: mouseTrap.select("#lr-mousetrap"),
       width: this.width - this.margin.left - this.margin.right,
       yScale: this.ratioYScale,
+      secondaryYScale: this.cnYScale,
     });
 
     const vafCursor = new YCursor({

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -288,10 +288,7 @@ class ChromosomePlot extends EventTarget {
       .select(this.element)
       .attr("preserveAspectRatio", "xMinYMin meet")
       .attr("viewBox", [0, 0, this.width, this.height])
-      .attr(
-        "style",
-        "max-width: 100%; height: auto; max-height: 500px; height: intrinsic;"
-      );
+      .attr("style", "height: auto; height: intrinsic;");
 
     this.#drawAxes();
 

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -194,7 +194,7 @@ class ChromosomePlot extends EventTarget {
       ? config.margin
       : {
           top: 10,
-          right: 30,
+          right: 60,
           bottom: 40,
           left: 60,
           between: 40,
@@ -1091,6 +1091,19 @@ class ChromosomePlot extends EventTarget {
       )
       .attr("class", "y-label")
       .text("log2 ratio")
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "text-before-edge");
+
+    this.svg
+      .append("text")
+      .attr(
+        "transform",
+        `translate(${this.width},${
+          this.margin.top + this.plotHeight / 2
+        }) rotate(90)`
+      )
+      .attr("class", "y-label")
+      .text("Copy number")
       .attr("text-anchor", "middle")
       .attr("dominant-baseline", "text-before-edge");
 

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -69,7 +69,7 @@ class GenomePlot extends EventTarget {
       .select("#genome-view")
       .attr("preserveAspectRatio", "xMinYMin meet")
       .attr("viewBox", [0, 0, this.width, this.height])
-      .attr("style", "max-width: 100%; max-height: 500px; height: auto;");
+      .attr("style", "height: auto;");
 
     this.#plotArea = this.svg
       .append("g")

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -11,6 +11,13 @@ const getTextDimensions = function (text, fontSize) {
   ];
 };
 
+const cnFromRatio = function (ratio, refPloidy) {
+  if (refPloidy === undefined) {
+    refPloidy = 2;
+  }
+  return refPloidy * 2 ** ratio;
+};
+
 d3.select("#dataset-picker")
   .selectAll("div")
   .data(cnvData[0].callers)

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -89,13 +89,11 @@
             <details class="no-print">
               <summary>Caveats</summary>
               <p>
-                Ploidy is assumed to be 2 across all chromosomes for copy number
+                All chromosomes are assumed to be diploid for copy number
                 calculations, including sex chromosomes. {% if
-                metadata.show_table or extra_tables | length > 0 %} Copy numbers
-                in the plot are not directly connected to the values in the
-                results table. Values in the table represent copy numbers
-                corrected by tumor cell content while the values in the plot are
-                uncorrected. {% endif %}
+                metadata.show_table %} Copy numbers are different in the plot
+                and the table. The table shows tumor content corrected values
+                while the plot shows uncorrected values. {% endif %}
               </p>
             </details>
             <dialog id="chromosome-view-dialog">

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -74,11 +74,30 @@
                   step="0.05"
                   value="0"
                 />
-                <input type="number" min="-2" max="2" step="0.05" id="current-baseline-offset" value="0.00"></input>
+                <input
+                  type="number"
+                  min="-2"
+                  max="2"
+                  step="0.05"
+                  id="current-baseline-offset"
+                  value="0.00"
+                />
                 <button id="reset-baseline-offset" disabled>Reset</button>
               </div>
             </div>
             <svg id="chromosome-view"></svg>
+            <details class="no-print">
+              <summary>Caveats</summary>
+              <p>
+                Ploidy is assumed to be 2 across all chromosomes for copy number
+                calculations, including sex chromosomes. {% if
+                metadata.show_table or extra_tables | length > 0 %} Copy numbers
+                in the plot are not directly connected to the values in the
+                results table. Values in the table represent copy numbers
+                corrected by tumor cell content while the values in the plot are
+                uncorrected. {% endif %}
+              </p>
+            </details>
             <dialog id="chromosome-view-dialog">
               <button class="close"><i class="bi bi-x-lg"></i></button>
             </dialog>
@@ -87,8 +106,7 @@
 
         {% if metadata.show_table or extra_tables | length > 0 %}
         <div class="table-container">
-        {% endif %}
-        {% if metadata.show_table %}
+          {% endif %} {% if metadata.show_table %}
           <section>
             <h2>Results table</h2>
             <p class="no-print">
@@ -113,9 +131,7 @@
             >
             <table id="cnv-table"></table>
           </section>
-        {% endif %}
-
-        {% if extra_tables | length > 0 %}
+          {% endif %} {% if extra_tables | length > 0 %}
           <section>
             <h2>Additional tables</h2>
 
@@ -132,15 +148,13 @@
                   </tr>
                 </thead>
                 <tbody>
-                  {% if table.data | length > 0 %}
-                  {% for row in table.data %}
+                  {% if table.data | length > 0 %} {% for row in table.data %}
                   <tr>
                     {% for h in table.header %}
                     <td>{{ row[h] }}</td>
                     {% endfor %}
                   </tr>
-                  {% endfor %}
-                  {% else %}
+                  {% endfor %} {% else %}
                   <tr>
                     <td colspan="{{ table.header | length }}">
                       No data available in table
@@ -152,8 +166,7 @@
             </section>
             {% endfor %}
           </section>
-        {% endif %}
-        {% if metadata.show_table or extra_tables | length > 0 %} 
+          {% endif %} {% if metadata.show_table or extra_tables | length > 0 %}
         </div>
         {% endif %}
       </div>

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -14,6 +14,28 @@ header .fix-right {
   right: 1em;
 }
 
+.plot-container div,
+.plot-container section {
+  max-width: 1000px;
+}
+
+details {
+  font-size: 0.8rem;
+  background-color: #aad1f2;
+  padding: 1rem;
+  margin: 1rem 0;
+  border-radius: 5px;
+}
+
+details summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+details p {
+  margin: 1rem 1rem 0.5rem 1rem;
+}
+
 dialog {
   user-select: none;
 }
@@ -63,11 +85,13 @@ dialog.info p i {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  justify-content: flex-start;
 }
 
 .plot-container {
   display: flex;
   flex-direction: column;
+  max-width: 1000px;
 }
 
 .plot-container .annotation-label {
@@ -97,6 +121,11 @@ dialog.info p i {
 
 #current-baseline-offset.invalid {
   background-color: #ff6762;
+}
+
+svg {
+  display: block;
+  max-width: 1000px;
 }
 
 svg .panel-overlay {
@@ -149,6 +178,7 @@ svg .cursor-label {
 
   .plot-container {
     min-width: 48%;
+    max-width: 1000px;
   }
 
   .plot-container .x-label,

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -62,6 +62,7 @@ dialog.info p i {
 .app-container {
   display: flex;
   flex-direction: column;
+  gap: 2rem;
 }
 
 .plot-container {


### PR DESCRIPTION
This PR adds a secondary axis to the log<sub>2</sub> ratio plot where the copy number is represented. The horizontal cursor has also been updated to also display the exact copy number.

At the moment a ploidy of 2 is assumed for every chromosome.

![copy_number_axis](https://github.com/user-attachments/assets/baa2915e-9c79-40d5-9618-78d775576018)
