### PR TITLE
feat(cnv): ability to manually adjust tumor cell content in plots

### DIFF
--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -915,7 +915,7 @@ class ChromosomePlot extends EventTarget {
     this.#vafArea
       .selectAll(".data-point")
       .data(vafData, (d) => {
-        if (d.mean) {
+        if (d.mean !== undefined) {
           return `${d.pos}-${d.start}-${d.end}:${d.mean < 0.5 ? "-" : "+"}`;
         }
         return `${this.data.chromosome}-${d.pos}`;

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -85,7 +85,9 @@ class GenomePlot extends EventTarget {
       );
 
     this.lrPanels = this.addPanels(lrArea);
-    this.vafPanels = this.addPanels(vafArea);
+    this.vafPanels = this.addPanels(vafArea)
+      .append("g")
+      .attr("clip-path", (_, i) => `url(#panel-${i}-overlay-clip)`);
 
     this.ratioPanels = this.lrPanels
       .append("g")
@@ -296,7 +298,8 @@ class GenomePlot extends EventTarget {
 
   setLabels() {
     // Labels
-    this.vafPanels
+    d3.select(this.vafPanels.node().parentNode.parentNode)
+      .selectAll(".chromosome-panel")
       .append("text")
       .attr(
         "transform",

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -390,6 +390,9 @@ class GenomePlot extends EventTarget {
                   self.ratioYScale(self.ratioYScale.domain()[1] - 2 * d.sd)
                 )
                 .attr("fill", "#333")
+                .attr("fill-opacity", 0)
+                .transition()
+                .duration(self.animationDuration)
                 .attr("fill-opacity", 0.3);
 
               g.append("line")
@@ -400,6 +403,9 @@ class GenomePlot extends EventTarget {
                 .attr("y2", (d) => self.ratioYScale(d.mean))
                 .attr("stroke", "#333")
                 .attr("stroke-width", 1)
+                .attr("opacity", 0)
+                .transition()
+                .duration(self.animationDuration)
                 .attr("opacity", 0.3);
               return g;
             } else {
@@ -410,6 +416,9 @@ class GenomePlot extends EventTarget {
                 .attr("cy", (d) => self.ratioYScale(d.log2))
                 .attr("r", 2)
                 .attr("fill", "#333")
+                .attr("fill-opacity", 0)
+                .transition()
+                .duration(self.animationDuration)
                 .attr("fill-opacity", 0.3);
             }
           },
@@ -418,6 +427,8 @@ class GenomePlot extends EventTarget {
               update
                 .selectAll(".variance-rect")
                 .data((d) => [d])
+                .transition()
+                .duration(self.animationDuration)
                 .attr("y", (d) => self.ratioYScale(d.mean + d.sd))
                 .attr("height", (d) =>
                   self.ratioYScale(self.ratioYScale.domain()[1] - 2 * d.sd)
@@ -426,13 +437,43 @@ class GenomePlot extends EventTarget {
               update
                 .selectAll(".mean-line")
                 .data((d) => [d])
+                .transition()
+                .duration(self.animationDuration)
                 .attr("y1", (d) => self.ratioYScale(d.mean))
                 .attr("y2", (d) => self.ratioYScale(d.mean));
+              return update;
             } else {
-              return update.attr("cy", (d) => self.ratioYScale(d.log2));
+              return update
+                .transition()
+                .duration(self.animationDuration)
+                .attr("cy", (d) => self.ratioYScale(d.log2));
             }
           },
-          (exit) => exit.remove()
+          (exit) => {
+            if (exit.data()[0]?.mean) {
+              exit
+                .selectAll(".variance-rect")
+                .transition()
+                .duration(self.animationDuration)
+                .attr("fill-opacity", 0)
+                .remove();
+
+              exit
+                .selectAll(".mean-line")
+                .transition()
+                .duration(self.animationDuration)
+                .attr("opacity", 0)
+                .remove();
+
+              exit.transition().delay(self.animationDuration).remove();
+            } else {
+              exit
+                .transition()
+                .duration(self.animationDuration)
+                .attr("fill-opacity", 0)
+                .remove();
+            }
+          }
         );
     });
   }
@@ -446,12 +487,13 @@ class GenomePlot extends EventTarget {
         .map((d) => {
           let td = { ...d };
           td.log2 = self.transformLog2Ratio(td.log2);
+          td.caller = panelData.callers[self.activeCaller].name;
           return td;
         });
 
       d3.select(this)
         .selectAll(".segment")
-        .data(panelSegments)
+        .data(panelSegments, (d) => `${d.caller}-${i}-${d.start}-${d.end}`)
         .join(
           (enter) => {
             return enter
@@ -461,15 +503,25 @@ class GenomePlot extends EventTarget {
               .attr("x2", (d) => self.xScales[i](d.end))
               .attr("y1", (d) => self.ratioYScale(d.log2))
               .attr("y2", (d) => self.ratioYScale(d.log2))
-              .attr("stroke-width", 2);
+              .attr("stroke-width", 2)
+              .attr("opacity", 0)
+              .transition()
+              .duration(self.animationDuration)
+              .attr("opacity", 1);
           },
           (update) => {
             return update
+              .transition()
+              .duration(self.animationDuration)
               .attr("y1", (d) => self.ratioYScale(d.log2))
               .attr("y2", (d) => self.ratioYScale(d.log2));
           },
           (exit) => {
-            exit.remove();
+            exit
+              .transition()
+              .duration(self.animationDuration)
+              .attr("opacity", 0)
+              .remove();
           }
         );
     });

--- a/workflow/templates/cnv_html_report/02-genome-plot.js
+++ b/workflow/templates/cnv_html_report/02-genome-plot.js
@@ -567,7 +567,7 @@ class GenomePlot extends EventTarget {
       d3.select(this)
         .selectAll(".data-point")
         .data(panelVaf, (d) => {
-          if (d.mean) {
+          if (d.mean !== undefined) {
             return `${i}-${d.start}-${d.end}:${d.mean < 0.5 ? "-" : "+"}`;
           }
           return `${i}-${d.pos}`;

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -205,6 +205,7 @@ simulatePurity.on("change", (e) => {
     tcAdjustReset.property("disabled", true);
   }
   chromosomePlot.setSimulatePurity(checked);
+  genomePlot.setSimulatePurity(checked);
 });
 
 tcAdjustSlider.on("change", () => {
@@ -243,7 +244,7 @@ currentTc.on("change", (e) => {
   tcAdjustSlider.node().value = tc;
   currentTc.node().value = strtc;
   chromosomePlot.setTc(tc);
-  // genomePlot.setTc(tc);
+  genomePlot.setTc(tc);
 });
 
 tcAdjustReset.on("click", () => {

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -190,9 +190,21 @@ baselineOffsetReset.on("click", () => {
   baselineOffsetSlider.node().dispatchEvent(new Event("change"));
 });
 
+const simulatePurity = d3.select("#simulate-purity");
 const tcAdjustSlider = d3.select("#tc-adjuster");
 const currentTc = d3.select("#current-tc");
 const tcAdjustReset = d3.select("#reset-tc");
+
+simulatePurity.on("change", (e) => {
+  const checked = e.target.checked;
+  tcAdjustSlider.property("disabled", !checked);
+  currentTc.property("disabled", !checked);
+  currentTc.node().dispatchEvent(new Event("change"));
+  if (!checked) {
+    tcAdjustReset.property("disabled", true);
+  }
+  // chromosomePlot.setSimulatePurity(checked);
+});
 
 tcAdjustSlider.on("change", () => {
   currentTc.node().dispatchEvent(new Event("change"));

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -41,6 +41,7 @@ d3.select("#dataset-picker")
 const chromosomePlot = new ChromosomePlot({
   element: document.querySelector("#chromosome-view"),
   data: cnvData[0],
+  tc: originalTc,
 });
 
 const genomePlot = new GenomePlot({
@@ -203,7 +204,7 @@ simulatePurity.on("change", (e) => {
   if (!checked) {
     tcAdjustReset.property("disabled", true);
   }
-  // chromosomePlot.setSimulatePurity(checked);
+  chromosomePlot.setSimulatePurity(checked);
 });
 
 tcAdjustSlider.on("change", () => {
@@ -241,7 +242,7 @@ currentTc.on("change", (e) => {
   const strtc = tc.toLocaleString("en-US", { minimumFractionDigits: 2 });
   tcAdjustSlider.node().value = tc;
   currentTc.node().value = strtc;
-  // chromosomePlot.setTc(tc);
+  chromosomePlot.setTc(tc);
   // genomePlot.setTc(tc);
 });
 

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -190,6 +190,56 @@ baselineOffsetReset.on("click", () => {
   baselineOffsetSlider.node().dispatchEvent(new Event("change"));
 });
 
+const tcAdjustSlider = d3.select("#tc-adjuster");
+const currentTc = d3.select("#current-tc");
+const tcAdjustReset = d3.select("#reset-tc");
+
+tcAdjustSlider.on("change", () => {
+  currentTc.node().dispatchEvent(new Event("change"));
+});
+
+tcAdjustSlider.on("input", (e) => {
+  const dv = parseFloat(e.target.value);
+  const strdv = dv.toLocaleString("en-US", { minimumFractionDigits: 2 });
+  currentTc.node().value = strdv;
+});
+
+currentTc.on("change", (e) => {
+  const minTc = e.target.min ? parseFloat(e.target.min) : 0;
+  const maxTc = e.target.max ? parseFloat(e.target.max) : 1;
+  const tc = parseFloat(e.target.value);
+
+  if (tc < minTc || tc > maxTc) {
+    e.target.classList.add("invalid");
+    e.target.title = `Value outside the valid range [${minTc}, ${maxTc}]`;
+    console.error(
+      `tumor cell content outside the valid range [${minTc}, ${maxTc}]`
+    );
+    return;
+  }
+
+  e.target.classList.remove("invalid");
+  e.target.title = "";
+
+  tcAdjustReset.property("disabled", true);
+  if (tc != originalTc) {
+    tcAdjustReset.property("disabled", false);
+  }
+
+  const strtc = tc.toLocaleString("en-US", { minimumFractionDigits: 2 });
+  tcAdjustSlider.node().value = tc;
+  currentTc.node().value = strtc;
+  // chromosomePlot.setTc(tc);
+  // genomePlot.setTc(tc);
+});
+
+tcAdjustReset.on("click", () => {
+  tcAdjustSlider.node().value = originalTc;
+  tcAdjustReset.property("disabled", true);
+  currentTc.node().value = originalTc;
+  tcAdjustSlider.node().dispatchEvent(new Event("change"));
+});
+
 d3.selectAll("input[name=dataset]").on("change", (e) => {
   chromosomePlot.activeCaller = parseInt(e.target.value);
   genomePlot.activeCaller = parseInt(e.target.value);

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -85,6 +85,8 @@
                 <button id="reset-baseline-offset" disabled>Reset</button>
               </div>
               <div>
+                <label for="simulate-purity">Simulate purity</label>
+                <input type="checkbox" id="simulate-purity" />
                 <label for="tc-adjuster">Tumor cell content</label>
                 <input
                   type="range"
@@ -93,6 +95,7 @@
                   max="1"
                   step="0.05"
                   value="{{ metadata.tc if metadata.tc is not none else 1 }}"
+                  disabled
                 />
                 <input
                   type="number"
@@ -101,6 +104,7 @@
                   step="0.05"
                   id="current-tc"
                   value="{{ metadata.tc if metadata.tc is not none else 1 }}"
+                  disabled
                 />
                 <button id="reset-tc" disabled>Reset</button>
               </div>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -91,7 +91,7 @@
                 <input
                   type="range"
                   id="tc-adjuster"
-                  min="0"
+                  min="0.05"
                   max="1"
                   step="0.05"
                   value="{{ metadata.tc if metadata.tc is not none else 1 }}"
@@ -99,7 +99,7 @@
                 />
                 <input
                   type="number"
-                  min="0"
+                  min="0.05"
                   max="1"
                   step="0.05"
                   id="current-tc"

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -84,6 +84,26 @@
                 />
                 <button id="reset-baseline-offset" disabled>Reset</button>
               </div>
+              <div>
+                <label for="tc-adjuster">Tumor cell content</label>
+                <input
+                  type="range"
+                  id="tc-adjuster"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value="{{ metadata.tc if metadata.tc is not none else 1 }}"
+                />
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  id="current-tc"
+                  value="{{ metadata.tc if metadata.tc is not none else 1 }}"
+                />
+                <button id="reset-tc" disabled>Reset</button>
+              </div>
             </div>
             <svg id="chromosome-view"></svg>
             <details class="no-print">
@@ -171,6 +191,7 @@
     </div>
     <script>
       let cnvData = {{ json | trim | indent(width=8) }};
+      const originalTc = {{ metadata.tc if tc is not none else 1 }};
     </script>
     <!-- prettier-ignore -->
     <script>

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -114,12 +114,13 @@ dialog.info p i {
   max-width: 60em;
 }
 
-#current-baseline-offset {
+#current-baseline-offset,
+#current-tc {
   width: 3rem;
   margin-right: 0.5rem;
 }
 
-#current-baseline-offset.invalid {
+input.invalid {
   background-color: #ff6762;
 }
 


### PR DESCRIPTION
This PR adds controls for adjusting the plots for tumor cell content. By default the plots represent the data assuming 100% tumor purity. By activating the functionality it defaults to the tumor cell content that was used as input for the report generation, and it can be adjusted between 0.05 and 1. Both log<sub>2</sub> ratios and VAFs are adjusted, both in the chromosome view and the genome view.

![chromosome_plot_outliers](https://github.com/user-attachments/assets/5b331ada-3bca-4d43-9403-2b35917315e4)

Some notes:
- The normal ploidy of all chromosomes is assumed to be 2.
- When viewing summarised data, the VAF can be interpreted as bimodal when the variance is high, but when looking at all points they are evenly distributed across the range. This check could probably be done in a smarter way, but I haven't even looked at it at this point.
- To avoid undefined values in the calculation, the lower bound on copy number is set to 0.001.

When displaying a summary of the log<sub>2</sub> ratios and one or more values that the summary is based on bottoms out, i.e. reaches the lower copy number threshold, then a red triangle is displayed at the same x-position as the data in question. The summary that is displayed then disregards these particular values to avoid having the standard deviation running wild.