### PR TITLE
feat(cnv): better help section

### DIFF
--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -10,6 +10,7 @@ reference:
 
 cnv_html_report:
   cytobands: true
+  show_table: true
   extra_tables:
     - path: config/extra_table1.tsv
       name: Extra table
@@ -32,7 +33,6 @@ cnv_html_report:
 general_html_report:
   final_directory_depth: 3
   multiqc_config: "config/reports/multiqc_config_dna.yaml"
-
 
 merge_cnv_json:
   annotations:

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,5 @@
 fonttools
+brotli
 networkx==2.7
 pre-commit>=3.3
 pycodestyle==2.8.0

--- a/workflow/templates/assets/css/icons.css
+++ b/workflow/templates/assets/css/icons.css
@@ -11,6 +11,7 @@
  * U+F33A: exclamation-triangle-fill
  * U+F332: exclamation-circle-fill
  * U+F430: info-circle-fill
+ * U+F504: question-circle-fill
  * U+F52A: search
  * U+F62A: x
  * U+F659: x-lg
@@ -19,7 +20,7 @@
 @font-face {
   font-display: block;
   font-family: "bootstrap-icons";
-  src: url("data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAANcAAsAAAAABegAAAMPAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHCoGYABcCoUUhDEBNgIkAxILEAAEIAWBEAeBABuyBFGU7UEb4MeC6eZHpEMiWh6HooRXXxgl+oF4+H6N37lv95tZ6GKGa6MEYvJIKJTOkGyvdL/f4GLVs+QQ0U4soSMBjwx06pVYJyJFBaX976jCZUB0cDhB/+eaeh+v4nkDncstIulmUXp6o9tsopvIsMqieUSjss2GtU0SEpnzlp/wF71UoNKocWkxafNQ7bOCdy+0y6EoAIA8pqMfFPEJrgFMqvgRtGyNTkoy+vHdB0v3fPnw+86YB7oiGXoQwFg6IQs1cySYza1OrFUuKf3l9xH26fPl9m2HZBRYe4fGhcah+o3as+qr6gJgBCtzYC1q8APAHwCmAZmDScK8qqmpqtMfoqmraqhpYVlE3t7S9/fUwwNzd0fQrCFOcoyAIYGXsaxbpfgsno8FDZZMjlPX7FXBiGC4YSVZmscIXsCbexxOCerMwwN1f0/f3pJ3d0jGMsYGLKtGmyOBNzIydoe54TPR/Pja7v7h9sroztGBO4ZnmWVEkAvr9OYStbzFbCwiKRviaEvZQIanKBsRsjwlY4SiuFiKi8S4RJSUSiYWd87VOSHBWTKMOyG5xnK2KiPKSjEKuAquQEHlu15XP6szZzeDaS0DVoM1IJ+DvGdV5FRmvYMGhzcISkqxaKwSqTI3yLs+2+ttFrqsi0y1E5QDvlQMUjRj5PViGoy6toE2or3RS4VLa8bP7dETtZM+7qATUtMSdKKbJyQOWOy+h/xZCln+HfK2B85fdiq4il1evvU4rtY3b7UIxG2v6Onq6mnQdgq2NtleD14AYjo8i//EbJgVf4tZH4JlFgV+XoIhaPkujJ52xG8V9ZiGDyMr5HxWv3osFfNHuUTCkcGbx4vo/jJGE+ko/lP8heiUxQ3MoEKVVqNgWaltmcgrhF58LanV68xizpy0Eq2mI6VUuuOlLb3zlp/3xm2vzHjsrpdeeGvffQ+998xtbxy77423HiP+QL8Fs+YlQEb3LYsUWeRREqVR5kLb/ca7z24/L/Kxmf/ThGeKek9HzPNRWO7FQw7Xl0gbPFpa8Op5o2d1GQA=")
+  src: url("data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAAO0AAsAAAAABsAAAANmAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHCoGYABkCoZIhUYBNgIkAxQLEgAEIAWBEAeBFxtoBVGU7UUL4EdCdhZzS0IzvoH6aKXF2pJrQTzMvd5L8omwVUNkYabGwsyTUMSOSM3NliCTc9nukdo+qSkGh+ef0gyM2IRMJhO30P0cshpLUk/QD4Dr+ieuqXtb1XnTAOQrVk1VNNrrIm08wIkMo8J0FPW8WoOwsUShz7nX7f6HAFaKlFHmLVi2Duex3edOEEYD0HXScE3qchMD8IRPQJVX3cTJ8tYKBhV4+KoD8/fxrK87uFnqQEwWkgBE0aT0gJr2oyJOprFqAjduVOjr9k3pbw9oA9VB2mSzrs/e116xv7N9tmH9bflreYBQ+GaM7swTi2m+1NTLm1QqVZCAw2FxB67Dc4uyJeCIJ/ZOo2aTtNu406Gtlk24CZCgSodKljgfJrDclVJGGlMBIQKhkFCWTUVkI06kbksFPBx3xypAOx3cbpNmE7VasMRp0uDcT7JQSctKjqnB6rlnZpQCVCWVjK0hg58ZXNMqFZhP6DpWt8KAjm+IC6W4AKaAaRok4O3py/fP3+fT8df/75gOhOtl2ejulbw/4McP+nYPz/KbAB7oN0rAQFCJLlnpS0IoFeSLglxeUMhZiwWGNSZGhjY3hwoRrJZCbisGvUce96oTeIETSE9N7e1fR2/oZNpl2Lgb5AbqL05dewe811OLh+UFSrd7jbfmFnlvGuXI3uhospXHGExHNj3zA17D3yLHLNU763Tw+jLAxVGEUdO+Ut2SFfPHwC+beX5u5YLNdk3JKq6+s2I5vGvBYUfgVeXHqEGyjUt1C9e1p6zM78Pla5uHP48/+j/euPf2gMVL5uHkm/Nvxb+3PPZw+fHL/59SGsia15uzO3dRZAD5ujtnvWz4EoJej8fbyAwLZHLKepwEAKQuDX0SpClRNBzXdRmXNmmiPAB+nCKAQHT7qvs7TRsw26QOcK3wOH6APqL/k8XSA5hRjoEzuj+qkf8ZMSpgB2tioI+vzcIsO2noUVaqBx2GGVmBimgWhCSM9QpOktWqrFoDvYEgdcYIvj2cpL5znMUbnmE3p2hwmL2c5ARnWcN+DnKeY+zmDBvYzxnOchiNN5CmQ5M2CgCg0uY3iyKqaGIQo5jEzFZC+y/tPbb7+FvI1PiBDt1469REZMhXa64TB5F23+E56mb/XZsjMBqv6ZR2qXHsIAAA")
     format("woff2");
 }
 
@@ -43,6 +44,9 @@
 }
 .bi-exclamation-circle-fill::before {
   content: "\f332";
+}
+.bi-question-circle-fill::before {
+  content: "\f504";
 }
 .bi-info-circle-fill::before {
   content: "\f430";

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -11,6 +11,56 @@ const getTextDimensions = function (text, fontSize) {
   ];
 };
 
+// Modal handling start
+function hideModalOnClick(evt) {
+  const dimensions = this.getBoundingClientRect();
+  if (
+    evt.clientX < dimensions.left ||
+    evt.clientX > dimensions.right ||
+    evt.clientY < dimensions.top ||
+    evt.clientY > dimensions.bottom
+  ) {
+    this.close();
+  }
+}
+
+document.querySelector("dialog .close").addEventListener("click", (e) => {
+  e.currentTarget.parentNode.close();
+});
+
+const messageModal = document.getElementById("chromosome-view-dialog");
+messageModal.addEventListener("click", hideModalOnClick);
+
+function setModalMessage(msg, className) {
+  let message = document.createElement("p");
+  const messageText = document.createTextNode(msg);
+
+  let icon = document.createElement("i");
+
+  if (className === "error") {
+    icon.className = "bi-exclamation-circle-fill";
+  } else if (className === "warning") {
+    icon.className = "bi-exclamation-circle-fill";
+  } else if (className === "info") {
+    icon.className = "bi-info-circle-fill";
+  }
+
+  message.appendChild(icon);
+  message.appendChild(messageText);
+
+  messageModal.className = className ? className : "";
+  messageModal.firstChild?.remove();
+  messageModal.prepend(message);
+}
+
+const helpModal = document.getElementById("help-modal");
+helpModal.addEventListener("click", hideModalOnClick);
+
+function showHelp() {
+  helpModal.showModal();
+}
+// Modal handling end
+
 const cnFromRatio = function (ratio, refPloidy) {
   if (refPloidy === undefined) {
     refPloidy = 2;
@@ -53,45 +103,6 @@ const resultsTable = new ResultsTable(d3.select("#cnv-table"), {
   data: cnvData,
   filter: d3.select("#table-filter-toggle").node().checked,
 });
-
-const messageModal = document.querySelector("dialog");
-messageModal.addEventListener("click", (e) => {
-  const modalDimensions = messageModal.getBoundingClientRect();
-  if (
-    e.clientX < modalDimensions.left ||
-    e.clientX > modalDimensions.right ||
-    e.clientY < modalDimensions.top ||
-    e.clientY > modalDimensions.bottom
-  ) {
-    messageModal.close();
-  }
-});
-
-document.querySelector("dialog button.close").addEventListener("click", (e) => {
-  e.currentTarget.parentNode.close();
-});
-
-function setModalMessage(msg, className) {
-  let message = document.createElement("p");
-  const messageText = document.createTextNode(msg);
-
-  let icon = document.createElement("i");
-
-  if (className === "error") {
-    icon.className = "bi-exclamation-circle-fill";
-  } else if (className === "warning") {
-    icon.className = "bi-exclamation-circle-fill";
-  } else if (className === "info") {
-    icon.className = "bi-info-circle-fill";
-  }
-
-  message.appendChild(icon);
-  message.appendChild(messageText);
-
-  messageModal.className = className ? className : "";
-  messageModal.firstChild?.remove();
-  messageModal.prepend(message);
-}
 
 chromosomePlot.addEventListener("zoom", (e) => {
   d3.selectAll(".data-range-warning").classed(

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -24,9 +24,12 @@ function hideModalOnClick(evt) {
   }
 }
 
-document.querySelector("dialog .close").addEventListener("click", (e) => {
-  e.currentTarget.parentNode.close();
-});
+for (const dialog of document.querySelectorAll("dialog .close")) {
+  dialog.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.currentTarget.parentNode.close();
+  });
+}
 
 const messageModal = document.getElementById("chromosome-view-dialog");
 messageModal.addEventListener("click", hideModalOnClick);

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -55,11 +55,12 @@
               >hydra-genetics/reports v0.5.0</a
             >
           </small>
+          <br />
+          <a href="#" onclick="showHelp();" class="help-link"
+            ><i class="bi bi-question-circle-fill"></i> Help</a
+          >
         </p>
         <!-- x-release-please-end-version -->
-        <a onclick="showHelp();" class="help-link"
-          ><i class="bi bi-question-circle-fill"></i> Help</a
-        >
       </header>
 
       <div class="app-container">

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -140,16 +140,6 @@
               </div>
             </div>
             <svg id="chromosome-view"></svg>
-            <details class="no-print">
-              <summary>Caveats</summary>
-              <p>
-                All chromosomes are assumed to be diploid for copy number
-                calculations, including sex chromosomes. {% if
-                metadata.show_table %} Copy numbers are different in the plot
-                and the table. The table shows tumor content corrected values
-                while the plot shows uncorrected values. {% endif %}
-              </p>
-            </details>
             <dialog id="chromosome-view-dialog">
               <a href="#" class="close"><i class="bi bi-x"></i> Close</a>
             </dialog>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -194,7 +194,9 @@
             </div>
             <svg id="chromosome-view"></svg>
             <dialog id="chromosome-view-dialog">
-              <a href="#" class="close"><i class="bi bi-x"></i> Close</a>
+              <a href="#" class="close"
+                ><i title="Close" class="bi bi-x"></i> Close</a
+              >
             </dialog>
           </section>
         </div>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -19,23 +19,52 @@
           <h1>CNV report &mdash; Help</h1>
         </header>
         <section>
-          <header>
-            <h2>Plotting caveats</h2>
-            <p>
-              All chromosomes are assumed to be diploid for copy number
-              calculations, including sex chromosomes. {% if metadata.show_table
-              %} Copy numbers are different in the plot and the table. The table
-              shows tumor content corrected values while the plot shows
-              uncorrected values. {% endif %}
-            </p>
+          <h2 id="help-copy-number-plots">Copy number plots</h2>
 
-            <h3>Tumor purity adjustment</h3>
-            <p>
-              Similar as for the copy number calculations in the plots, the
-              tumor purity adjustment also assumes that all chromosomes are
-              diploid.
-            </p>
-          </header>
+          <h3 id="help-plotting-caveats">Plotting caveats</h3>
+          <p>
+            All chromosomes are assumed to be diploid for copy number
+            calculations, including sex chromosomes. {% if metadata.show_table
+            %} Copy numbers are different in the plot and the table. The table
+            shows tumor content corrected values while the plot shows
+            uncorrected values. {% endif %}
+          </p>
+
+          <h3 id="help-tumor-purity-adjustment">Tumor purity adjustment</h3>
+          <p>
+            Similar as for the copy number calculations in the plots, the tumor
+            purity adjustment also assumes that all chromosomes are diploid.
+          </p>
+          <p>
+            The smallest possible copy number is limited to 0.001 copies. When
+            displaying all points this will show as points lining up at that
+            copy number. For summarised data, the rectangles will represent the
+            mean and standard deviation for all points that do not end up below
+            this threshold. If there are points in a summarised window that fall
+            under the threshold, this will be indicated with a red triangle at
+            the bottom of the plot. This might be an indication that the copy
+            number is lower than the real copy number.
+          </p>
+
+          <h2 id="help-results-table">Results table</h2>
+          <p>
+            The results table presents copy number variants that have been
+            called by the selected caller.
+          </p>
+          <p>
+            Note that variants labelled as COPY_NORMAL can be present in the
+            filtered table. This indicates that there is a variant covering the
+            same gene that has been called by a different caller.
+          </p>
+          <p>
+            Click the magnifying glass to zoom in on the region in question.
+            Hover over the copy number to see what results other callers got for
+            this gene.
+          </p>
+          <p>
+            BAF values outside the range 0&ndash;1 might indicate that the tumor
+            cell content is underestimated.
+          </p>
         </section>
       </dialog>
       <header>
@@ -70,13 +99,29 @@
           </fieldset>
 
           <section class="genome-view plot-section">
-            <h2>Genome view</h2>
+            <h2>
+              Genome view
+              <a
+                class="help-link"
+                href="#help-copy-number-plots"
+                onclick="showHelp()"
+                ><i class="bi bi-question-circle-fill"></i
+              ></a>
+            </h2>
             <p class="no-print">Click a chromosome to visualise it below.</p>
             <svg id="genome-view"></svg>
           </section>
 
           <section class="chromosome-view plot-section">
-            <h2>Chromosome view</h2>
+            <h2>
+              Chromosome view
+              <a
+                class="help-link"
+                href="#help-copy-number-plots"
+                onclick="showHelp()"
+                ><i class="bi bi-question-circle-fill"></i
+              ></a>
+            </h2>
             <p class="no-print">
               Click and drag to zoom along x-axis. Click the plot to reset zoom.
             </p>
@@ -151,21 +196,15 @@
         <div class="table-container">
           {% endif %} {% if metadata.show_table %}
           <section>
-            <h2>Results table</h2>
-            <p class="no-print">
-              Click the magnifying glass to zoom in on the region in question.
-              Hover over the copy number to see what results other callers got
-              for this gene.
-            </p>
-            <p>
-              BAF values outside the range 0&ndash;1 might indicate that the
-              tumor cell content is underestimated.
-            </p>
-            <p>
-              Note that variants labelled as COPY_NORMAL can be present in the
-              filtered table. This indicates that there is a variant covering
-              the same gene that has been called by a different caller.
-            </p>
+            <h2>
+              Results table
+              <a
+                class="help-link"
+                href="#help-results-table"
+                onclick="showHelp()"
+                ><i class="bi bi-question-circle-fill"></i
+              ></a>
+            </h2>
             <input type="checkbox" id="table-filter-toggle" checked />
             <label
               for="table-filter-toggle"

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -92,7 +92,7 @@
             >
           </small>
           <br />
-          <a href="#" onclick="showHelp();" class="help-link"
+          <a href="#" onclick="showHelp();" class="no-print help-link"
             ><i class="bi bi-question-circle-fill"></i> Help</a
           >
         </p>
@@ -109,7 +109,7 @@
             <h2>
               Genome view
               <a
-                class="help-link"
+                class="no-print help-link"
                 href="#help-copy-number-plots"
                 onclick="showHelp()"
                 ><i class="bi bi-question-circle-fill"></i
@@ -123,7 +123,7 @@
             <h2>
               Chromosome view
               <a
-                class="help-link"
+                class="no-print help-link"
                 href="#help-copy-number-plots"
                 onclick="showHelp()"
                 ><i class="bi bi-question-circle-fill"></i
@@ -206,7 +206,7 @@
             <h2>
               Results table
               <a
-                class="help-link"
+                class="no-print help-link"
                 href="#help-results-table"
                 onclick="showHelp()"
                 ><i class="bi bi-question-circle-fill"></i

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -57,6 +57,11 @@
             same gene that has been called by a different caller.
           </p>
           <p>
+            By checking the "Filter table" checkbox (checked by default), only
+            copy number variants in the filtered callset will be presented.
+            Unchecking it will show all variants.
+          </p>
+          <p>
             Click the magnifying glass to zoom in on the region in question.
             Hover over the copy number to see what results other callers got for
             this gene.

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -46,6 +46,7 @@
             number is lower than the real copy number.
           </p>
 
+          {% if metadata.show_table %}
           <h2 id="help-results-table">Results table</h2>
           <p>
             The results table presents copy number variants that have been
@@ -70,6 +71,7 @@
             BAF values outside the range 0&ndash;1 might indicate that the tumor
             cell content is underestimated.
           </p>
+          {% endif %}
         </section>
       </dialog>
       <header>

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -11,6 +11,33 @@
   </head>
   <body>
     <div class="container">
+      <dialog id="help-modal" class="help-contents">
+        <a href="#" class="close"
+          ><i title="Close" class="bi bi-x"></i> Close</a
+        >
+        <header>
+          <h1>CNV report &mdash; Help</h1>
+        </header>
+        <section>
+          <header>
+            <h2>Plotting caveats</h2>
+            <p>
+              All chromosomes are assumed to be diploid for copy number
+              calculations, including sex chromosomes. {% if metadata.show_table
+              %} Copy numbers are different in the plot and the table. The table
+              shows tumor content corrected values while the plot shows
+              uncorrected values. {% endif %}
+            </p>
+
+            <h3>Tumor purity adjustment</h3>
+            <p>
+              Similar as for the copy number calculations in the plots, the
+              tumor purity adjustment also assumes that all chromosomes are
+              diploid.
+            </p>
+          </header>
+        </section>
+      </dialog>
       <header>
         <h1>CNV report</h1>
         <ul>
@@ -30,6 +57,9 @@
           </small>
         </p>
         <!-- x-release-please-end-version -->
+        <a onclick="showHelp();" class="help-link"
+          ><i class="bi bi-question-circle-fill"></i> Help</a
+        >
       </header>
 
       <div class="app-container">
@@ -121,7 +151,7 @@
               </p>
             </details>
             <dialog id="chromosome-view-dialog">
-              <button class="close"><i class="bi bi-x-lg"></i></button>
+              <a href="#" class="close"><i class="bi bi-x"></i> Close</a>
             </dialog>
           </section>
         </div>

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -49,6 +49,7 @@ details p {
   background-color: white;
   width: 60%;
   margin: 0 auto;
+  max-height: 70%;
 }
 
 dialog .close {

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -10,6 +10,7 @@ header {
 
 header .fix-right {
   position: absolute;
+  text-align: right;
   top: 0;
   right: 1em;
 }
@@ -39,7 +40,6 @@ details p {
 .help-link {
   text-decoration: none;
   color: steelblue;
-  font-size: 2rem;
   cursor: pointer;
 }
 

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -36,21 +36,31 @@ details p {
   margin: 1rem 1rem 0.5rem 1rem;
 }
 
-dialog {
+.help-link {
+  text-decoration: none;
+  color: steelblue;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.help-contents {
+  position: fixed;
+  top: 50px;
+  background-color: white;
+  width: 60%;
+  margin: 0 auto;
+}
+
+dialog .close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  text-decoration: none;
   user-select: none;
 }
 
-dialog button.close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 1rem;
-  width: 1rem;
-  overflow: hidden;
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  cursor: pointer;
+#chromosome-view-dialog {
+  user-select: none;
 }
 
 dialog p i {


### PR DESCRIPTION
This PR adds a separate help view for the CNV report. It can be opened by either clicking the help link in the upper right corner, or by clicking the question marks for each section. The help can be closed by either clicking the close link in the help, clicking outside the help view, or pressing escape on the keyboard.

All help text has now been moved from the main report into the help view.

The current content of the help section is as follows:

> # CNV report — Help
> ## Copy number plots
> ### Plotting caveats
> All chromosomes are assumed to be diploid for copy number calculations, including sex chromosomes. Copy numbers are different in the plot and the table. The table shows tumor content corrected values while the plot shows uncorrected values.
>
> ### Tumor purity adjustment
> Similar as for the copy number calculations in the plots, the tumor purity adjustment also assumes that all chromosomes are diploid.
>
> The smallest possible copy number is limited to 0.001 copies. When displaying all points this will show as points lining up at that copy number. For summarised data, the rectangles will represent the mean and standard deviation for all points that do not end up below this threshold. If there are points in a summarised window that fall under the threshold, this will be indicated with a red triangle at the bottom of the plot. This might be an indication that the copy number is lower than the real copy number.
>
> ## Results table
> The results table presents copy number variants that have been called by the selected caller.
>
> Note that variants labelled as COPY_NORMAL can be present in the filtered table. This indicates that there is a variant covering the same gene that has been called by a different caller.
>
> By checking the "Filter table" checkbox (checked by default), only copy number variants in the filtered callset will be presented. Unchecking it will show all variants.
>
> Click the magnifying glass to zoom in on the region in question. Hover over the copy number to see what results other callers got for this gene.
>
> BAF values outside the range 0–1 might indicate that the tumor cell content is underestimated.

Any suggestions on what to add or reformulate are appreciated.