### PR TITLE
feat(cnv): replace chromosome and start with position

### DIFF
--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -204,60 +204,6 @@ def filter_chr_cnvs(unfiltered_cnvs: Dict[str, List[CNV]], filtered_cnvs: Dict[s
     return cnvs
 
 
-def filter_chr_cnvs(unfiltered_cnvs: Dict[str, List[CNV]], filtered_cnvs: Dict[str, List[CNV]]) -> Dict[str, List[Dict]]:
-    if len(unfiltered_cnvs) == 0:
-        return {}
-    callers = sorted(list(unfiltered_cnvs.keys()))
-    first_caller = callers[0]
-    rest_callers = callers[1:]
-
-    # Keep track of added CNVs (and filter status) on a chromosome to avoid duplicates
-    added_cnvs = {}
-
-    for cnv1 in unfiltered_cnvs[first_caller]:
-        pass_filter = False
-
-        if cnv1 in filtered_cnvs.get(first_caller, []):
-            # The CNV is part of the filtered set, so all overlapping
-            # CNVs should pass the filter.
-            pass_filter = True
-
-        cnv_group = [cnv1]
-        for caller2 in rest_callers:
-            for cnv2 in unfiltered_cnvs[caller2]:
-                if cnv1.overlaps(cnv2):
-                    # Add overlapping CNVs from other callers
-                    cnv_group.append(cnv2)
-
-                    if cnv2 in filtered_cnvs.get(caller2, []):
-                        # If the overlapping CNV is part of the filtered
-                        # set, the whole group should pass the filter.
-                        pass_filter = True
-
-        for c in cnv_group:
-            # Track CNV filter status.
-            # If a CNV that was previously set to not pass the filter,
-            # but later passes due to another comparison, then update
-            # the filter status.
-            if c not in added_cnvs or pass_filter:
-                added_cnvs[c] = pass_filter
-
-    cnvs = defaultdict(list)
-    for c, pass_filter in added_cnvs.items():
-        cnvs[c.caller].append(
-            dict(
-                genes=c.genes,
-                start=c.start,
-                length=c.length,
-                type=c.type,
-                cn=c.copy_number,
-                baf=c.baf,
-                passed_filter=pass_filter,
-            )
-        )
-    return cnvs
-
-
 def merge_cnv_dicts(dicts, vaf, annotations, cytobands, chromosomes, filtered_cnvs, unfiltered_cnvs):
     callers = list(map(lambda x: x["caller"], dicts))
     caller_labels = dict(

--- a/workflow/templates/cnv_html_report/03-results-table.js
+++ b/workflow/templates/cnv_html_report/03-results-table.js
@@ -100,8 +100,9 @@ class ResultsTable extends EventTarget {
 
       case "position":
         return {
-          class: "left clipboard-copy",
-          format: (x) => x,
+          class: "left",
+          format: (x) =>
+            `<span class="clipboard-copy" title="Copy to clipboard">${x}</span>`,
         };
 
       // Strings

--- a/workflow/templates/cnv_html_report/03-results-table.js
+++ b/workflow/templates/cnv_html_report/03-results-table.js
@@ -183,8 +183,10 @@ class ResultsTable extends EventTarget {
           )
           .map((di) => {
             const cols = { view: "", chromosome: d.chromosome, ...di };
-            const end = di.start + di.length;
-            cols.position = `${d.chromosome}:${di.start}-${end}`;
+            const end = (di.start + di.length).toLocaleString();
+            cols.position = `${
+              d.chromosome
+            }:${di.start.toLocaleString()}-${end}`;
             return cols;
           })
       )

--- a/workflow/templates/cnv_html_report/03-results-table.js
+++ b/workflow/templates/cnv_html_report/03-results-table.js
@@ -98,10 +98,15 @@ class ResultsTable extends EventTarget {
           format: (x) => x.join(", "),
         };
 
+      case "position":
+        return {
+          class: "left clipboard-copy",
+          format: (x) => x,
+        };
+
       // Strings
       case "caller":
       case "chromosome":
-      case "position":
       default:
         return {
           class: "left",
@@ -245,6 +250,23 @@ class ResultsTable extends EventTarget {
       .join("td")
       .html((d) => this.columnDef(d.column).format(d.value))
       .attr("class", (d) => this.columnDef(d.column).class);
+
+    this.#body.selectAll(".clipboard-copy").on("click", (e) => {
+      const text = e.target.innerHTML;
+      navigator.permissions
+        .query({ name: "clipboard-write" })
+        .then((result) => {
+          if (result.state == "granted" || result.state == "prompt") {
+            navigator.clipboard
+              .writeText(text)
+              .catch((res) =>
+                console.error("failed to write to clipboard: ", res)
+              );
+          } else {
+            console.warn("permission denied: writing to clipboard");
+          }
+        });
+    });
 
     this.#body.selectAll(".view-region-link").on("click", (e) => {
       const rowData = e.target.parentNode.parentElement.dataset;

--- a/workflow/templates/cnv_html_report/index.html
+++ b/workflow/templates/cnv_html_report/index.html
@@ -71,6 +71,10 @@
             BAF values outside the range 0&ndash;1 might indicate that the tumor
             cell content is underestimated.
           </p>
+          <p>
+            Clicking the position will copy the string to the system clipboard,
+            and the format should be compatible with most genome viewers.
+          </p>
           {% endif %}
         </section>
       </dialog>

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -356,6 +356,10 @@ tbody tr:hover {
   cursor: pointer;
 }
 
+td.clipboard-copy {
+  cursor: copy;
+}
+
 .panel-overlay {
   stroke-width: 0;
 }

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -356,7 +356,7 @@ tbody tr:hover {
   cursor: pointer;
 }
 
-td.clipboard-copy {
+.clipboard-copy {
   cursor: copy;
 }
 

--- a/workflow/templates/cnv_html_report/style.css
+++ b/workflow/templates/cnv_html_report/style.css
@@ -304,23 +304,23 @@ th {
 }
 
 #cnv-table th:nth-child(2) {
-  width: 15%;
+  width: 25%;
 }
 
 #cnv-table th:nth-child(3) {
-  width: 15%;
+  width: 10%;
 }
 
 #cnv-table th:nth-child(4) {
-  width: 15%;
+  width: 20%;
 }
 
 #cnv-table th:nth-child(5) {
-  width: 20%;
+  width: 10%;
 }
 
 #cnv-table th:nth-child(6) {
-  width: 20%;
+  width: 10%;
 }
 
 #cnv-table th:nth-child(7) {


### PR DESCRIPTION
This PR replaces the chromosome and start position in the results table with a position column. The format should be compatible with most genome browsers. The position gets copied to the clipboard upon clicking it, but it currently does not have any indication that this happens. It is documented in the help view, and hovering the position shows that this is possible to do.

![image](https://github.com/user-attachments/assets/83fcaa99-2574-4d31-9205-1bd0ccdc50a3)

Not quite sure about the end position though. The VCF spec says that the start is 1-based and inclusive, so assuming that the length is correct, these should be correct, but let me know if I've gotten anything wrong.