### PR TITLE
fix(cnv): bug with missing results in table

### DIFF
--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf
@@ -5,6 +5,7 @@
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
+chrA	1100	.	N	<DUP>	.	.	Genes=gene1;SVTYPE=DUP;END=1400;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10
 chrA	3000	.	N	<DUP>	.	.	Genes=gene2;SVTYPE=DUP;END=4000;SVLEN=1000;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10
 chrA	4000	.	N	<DUP>	.	.	Genes=geneB,geneC;SVTYPE=DUP;END=5000;SVLEN=1000;BAF=0.3;CALLER=gatk;CORR_CN=3	GT:CN	0/1:3
 chrB	4000	.	N	<DUP>	.	.	Genes=gene4;SVTYPE=DUP;END=5000;SVLEN=1000;BAF=0.5;CALLER=cnvkit;CORR_CN=9	GT:CN	0/1:9

--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.vcf
@@ -4,7 +4,9 @@
 ##contig=<ID=chrM>
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=CORR_CN,Number=1,Type=Integer,Description="Corrected copy number">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
+chrA	1100	.	N	<DUP>	.	.	Genes=gene1;SVTYPE=DUP;END=1400;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10
 chrA	1500	.	N	<COPY_NORMAL>	.	.	Genes=geneA;SVTYPE=COPY_NORMAL;END=2500;SVLEN=1000;BAF=0.5;CALLER=cnvkit;CORR_CN=2	GT:CN	0/0:2
 chrA	3000	.	N	<DUP>	.	.	Genes=gene2;SVTYPE=DUP;END=4000;SVLEN=1000;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10
 chrA	4000	.	N	<COPY_NORMAL>	.	.	Genes=geneB,geneC;SVTYPE=COPY_NORMAL;END=5000;SVLEN=1000;BAF=0.5;CALLER=cnvkit;CORR_CN=2	GT:CN	0/0:2

--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.1
+##contig=<ID=chrA>
+##contig=<ID=chrB>
+##contig=<ID=chrM>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=CORR_CN,Number=1,Type=Integer,Description="Corrected copy number">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
+chrA	800	.	N	<DEL>	.	.	Genes=gene1;SVTYPE=DEL;END=1100;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=1	GT:CN	0/1:1

--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.1
+##contig=<ID=chrA>
+##contig=<ID=chrB>
+##contig=<ID=chrM>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=CORR_CN,Number=1,Type=Integer,Description="Corrected copy number">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
+chrA	800	.	N	<DEL>	.	.	Genes=gene1;SVTYPE=DEL;END=1100;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=1	GT:CN	0/1:1

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -42,9 +42,11 @@ merge_cnv_json:
   cytobands: config/cytobands.txt
   filtered_cnv_vcfs:
     - cnv_sv/svdb_query/{sample}_{type}.{tc_method}.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf
+    - cnv_sv/svdb_query/{sample}_{type}.{tc_method}.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf
   germline_vcf: snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.exclude.blacklist.vcf
   unfiltered_cnv_vcfs:
     - cnv_sv/svdb_query/{sample}_{type}.{tc_method}.svdb_query.annotate_cnv.cnv_amp_genes.vcf
+    - cnv_sv/svdb_query/{sample}_{type}.{tc_method}.svdb_query.annotate_cnv.cnv_loh_genes.vcf
 
 svdb_merge:
   tc_method:

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 import os
 import sys
-from typing import Dict, List
+from typing import Any, Dict, List, Tuple
 import unittest
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPT_DIR = os.path.abspath(os.path.join(TEST_DIR, "../../workflow/scripts"))
 sys.path.insert(0, SCRIPT_DIR)
 
-from merge_cnv_json import CNV, filter_chr_cnvs  # noqa
+from merge_cnv_json import CNV, filter_chr_cnvs, merge_cnv_dicts  # noqa
 
 
 class TestMergeCnvJson(unittest.TestCase):
@@ -174,3 +174,143 @@ class TestMergeCnvJson(unittest.TestCase):
                 assert len(cnvs) == case.expected_lens[caller]
                 for cnv, expected_filter in zip(cnvs, case.expected_filter[caller]):
                     assert cnv["passed_filter"] == expected_filter
+
+    def test_merge_cnv_dicts(self):
+        @dataclass
+        class TestCase:
+            chromosomes: List[Tuple[str, int]]
+            callers: List[Dict[str, str]]
+            unfiltered_cnvs: List[List[CNV]]
+            filtered_cnvs: List[List[CNV]]
+            expected_cnvs: Dict[str, Any]
+
+        testcases = [
+            TestCase(
+                chromosomes=[("chr1", 1000)],
+                callers=[
+                    {
+                        "caller": "cnvkit",
+                        "segments": [],
+                        "ratios": [],
+                    },
+                ],
+                unfiltered_cnvs=[
+                    # File with amplifications
+                    {
+                        "chr1": {
+                            "cnvkit": [
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene1"],
+                                    start=100,
+                                    length=100,
+                                    type="DUP",
+                                    copy_number=6,
+                                    baf=0.3,
+                                ),
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene2"],
+                                    start=500,
+                                    length=100,
+                                    type="COPY_NORMAL",
+                                    copy_number=2,
+                                    baf=0.5,
+                                ),
+                            ],
+                        },
+                    },
+                    # File with deletions
+                    {
+                        "chr1": {
+                            "cnvkit": [
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene1"],
+                                    start=200,
+                                    length=100,
+                                    type="COPY_NORMAL",
+                                    copy_number=1,
+                                    baf=0.5,
+                                ),
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene2"],
+                                    start=600,
+                                    length=100,
+                                    type="DEL",
+                                    copy_number=1,
+                                    baf=0.3,
+                                ),
+                            ],
+                        },
+                    },
+                ],
+                filtered_cnvs=[
+                    # Filtered amplifications
+                    {
+                        "chr1": {
+                            "cnvkit": [
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene1"],
+                                    start=100,
+                                    length=100,
+                                    type="DUP",
+                                    copy_number=6,
+                                    baf=0.3,
+                                ),
+                            ],
+                        },
+                    },
+                    # Filtered deletions
+                    {
+                        "chr1": {
+                            "cnvkit": [
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene2"],
+                                    start=600,
+                                    length=100,
+                                    type="DEL",
+                                    copy_number=1,
+                                    baf=0.3,
+                                ),
+                            ],
+                        },
+                    },
+                ],
+                expected_cnvs={
+                    "chr1": {
+                        "cnvkit": {
+                            # All four calls should end up in the results...
+                            "all_count": 4,
+                            # ... and two of them should pass the filtering
+                            "pass_filter_count": 2,
+                        }
+                    }
+                },
+            )
+        ]
+
+        for case in testcases:
+            d = merge_cnv_dicts(case.callers, [], [], [], case.chromosomes, case.filtered_cnvs, case.unfiltered_cnvs)
+
+            for chromosome in case.expected_cnvs:
+                chromosomedata = [x for x in d if x["chromosome"] == chromosome]
+                assert len(chromosomedata) == 1
+
+                for caller in case.expected_cnvs[chromosome]:
+                    callerdata = [x for x in chromosomedata[0]["callers"] if x["name"] == caller]
+                    assert len(callerdata) == 1
+
+                    assert case.expected_cnvs[chromosome][caller]["all_count"] == len(callerdata[0]["cnvs"])
+
+                    n_pass_filter = sum(x["passed_filter"] for x in callerdata[0]["cnvs"])
+                    assert n_pass_filter == case.expected_cnvs[chromosome][caller]["pass_filter_count"]

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -226,6 +226,18 @@ class TestMergeCnvJson(unittest.TestCase):
                     {
                         "chr1": {
                             "cnvkit": [
+                                # This variant is present in the other file too,
+                                # but we don't want duplicates in the final data.
+                                CNV(
+                                    caller="cnvkit",
+                                    chromosome="chr1",
+                                    genes=["gene2"],
+                                    start=500,
+                                    length=100,
+                                    type="COPY_NORMAL",
+                                    copy_number=2,
+                                    baf=0.5,
+                                ),
                                 CNV(
                                     caller="cnvkit",
                                     chromosome="chr1",

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -11,6 +11,36 @@ sys.path.insert(0, SCRIPT_DIR)
 from merge_cnv_json import CNV, filter_chr_cnvs, merge_cnv_dicts  # noqa
 
 
+class TestCNV(unittest.TestCase):
+    def test_membership(self):
+        cnv = CNV(
+            caller="cnvkit",
+            chromosome="chr1",
+            start=100,
+            length=100,
+            type="COPY_NORMAL",
+            genes=[],
+            cn=2,
+            baf=0.5,
+            passed_filter=True,
+        )
+
+        cnv_collection = [
+            CNV(
+                caller="cnvkit",
+                chromosome="chr1",
+                start=100,
+                length=100,
+                type="COPY_NORMAL",
+                genes=[],
+                cn=2,
+                baf=0.5,
+            ),
+        ]
+
+        assert cnv in cnv_collection
+
+
 class TestMergeCnvJson(unittest.TestCase):
     def test_cnv_filter(self):
         """

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -51,7 +51,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=1000,
                             length=2500,
                             type="COPY_NORMAL",
-                            copy_number=2,
+                            cn=2,
                             baf=0.5,
                         ),
                         CNV(
@@ -61,7 +61,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=4000,
                             length=1000,
                             type="DUP",
-                            copy_number=9,
+                            cn=9,
                             baf=0.5,
                         ),
                         CNV(
@@ -71,7 +71,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=5800,
                             length=400,
                             type="COPY_NORMAL",
-                            copy_number=2,
+                            cn=2,
                             baf=0.6,
                         ),
                     ],
@@ -83,7 +83,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=10,
                             length=7190,
                             type="COPY_NORMAL",
-                            copy_number=2,
+                            cn=2,
                             baf=0.6,
                         )
                     ],
@@ -103,7 +103,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=132_309,
                             length=3_598_391,
                             type="DEL",
-                            copy_number=1.41,
+                            cn=1.41,
                             baf=0.5,
                         ),
                         CNV(
@@ -113,7 +113,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=3_731_199,
                             length=31_683_311,
                             type="COPY_NORMAL",
-                            copy_number=1.85,
+                            cn=1.85,
                             baf=0.5,
                         ),
                         CNV(
@@ -123,7 +123,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=66_483_605,
                             length=4_031_951,
                             type="DEL",
-                            copy_number=1.28,
+                            cn=1.28,
                             baf=0.5,
                         ),
                         CNV(
@@ -133,7 +133,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=87_570_960,
                             length=2_524_518,
                             type="DEL",
-                            copy_number=1.20,
+                            cn=1.20,
                             baf=0.5,
                         ),
                     ],
@@ -145,7 +145,7 @@ class TestMergeCnvJson(unittest.TestCase):
                             start=132_060,
                             length=89_963_668,
                             type="COPY_NORMAL",
-                            copy_number=0.99,
+                            cn=0.99,
                             baf=0.5,
                         )
                     ],
@@ -173,7 +173,7 @@ class TestMergeCnvJson(unittest.TestCase):
             for caller, cnvs in m.items():
                 assert len(cnvs) == case.expected_lens[caller]
                 for cnv, expected_filter in zip(cnvs, case.expected_filter[caller]):
-                    assert cnv["passed_filter"] == expected_filter
+                    assert cnv.passed_filter == expected_filter
 
     def test_merge_cnv_dicts(self):
         @dataclass
@@ -206,7 +206,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=100,
                                     length=100,
                                     type="DUP",
-                                    copy_number=6,
+                                    cn=6,
                                     baf=0.3,
                                 ),
                                 CNV(
@@ -216,7 +216,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=500,
                                     length=100,
                                     type="COPY_NORMAL",
-                                    copy_number=2,
+                                    cn=2,
                                     baf=0.5,
                                 ),
                             ],
@@ -235,7 +235,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=500,
                                     length=100,
                                     type="COPY_NORMAL",
-                                    copy_number=2,
+                                    cn=2,
                                     baf=0.5,
                                 ),
                                 CNV(
@@ -245,7 +245,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=200,
                                     length=100,
                                     type="COPY_NORMAL",
-                                    copy_number=1,
+                                    cn=1,
                                     baf=0.5,
                                 ),
                                 CNV(
@@ -255,7 +255,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=600,
                                     length=100,
                                     type="DEL",
-                                    copy_number=1,
+                                    cn=1,
                                     baf=0.3,
                                 ),
                             ],
@@ -274,7 +274,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=100,
                                     length=100,
                                     type="DUP",
-                                    copy_number=6,
+                                    cn=6,
                                     baf=0.3,
                                 ),
                             ],
@@ -291,7 +291,7 @@ class TestMergeCnvJson(unittest.TestCase):
                                     start=600,
                                     length=100,
                                     type="DEL",
-                                    copy_number=1,
+                                    cn=1,
                                     baf=0.3,
                                 ),
                             ],
@@ -324,5 +324,5 @@ class TestMergeCnvJson(unittest.TestCase):
 
                     assert case.expected_cnvs[chromosome][caller]["all_count"] == len(callerdata[0]["cnvs"])
 
-                    n_pass_filter = sum(x["passed_filter"] for x in callerdata[0]["cnvs"])
+                    n_pass_filter = sum(x.passed_filter for x in callerdata[0]["cnvs"])
                     assert n_pass_filter == case.expected_cnvs[chromosome][caller]["pass_filter_count"]

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -37,9 +37,9 @@ class TestMergeCnvJson(unittest.TestCase):
             #
             # n: copy normal, ^: duplication
             #
-            # cnvkit:           nnnnnnnnnn          ^^^^^^^^^^
-            # gatk:   nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-            # chr1:   __________________________________________________
+            # cnvkit:          nnnnnnnnnnnnnnnnnnnnnnnnn     ^^^^^^^^^^^       nnnn
+            # gatk:    nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+            # chr1:   ________________________________________________________________________
             TestCase(
                 name="table filter bug",
                 input={

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -8,7 +8,7 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPT_DIR = os.path.abspath(os.path.join(TEST_DIR, "../../workflow/scripts"))
 sys.path.insert(0, SCRIPT_DIR)
 
-from merge_cnv_json import CNV, filter_chr_cnvs, merge_cnv_dicts, get_cnvs, merge_cnv_calls  # noqa
+from merge_cnv_json import CNV, filter_chr_cnvs, merge_cnv_dicts, get_cnvs, merge_cnv_calls, sort_cnvs  # noqa
 
 
 class TestCNV(unittest.TestCase):
@@ -398,3 +398,22 @@ class TestMergeCnvJson(unittest.TestCase):
         assert sum(x.passed_filter for x in cnvkit_cnvs) == 4 + 1  # 3 amp + 1 del + 1 overlap with gatk
         assert sum(x.passed_filter for x in gatk_cnvs) == 1 + 1  # 1 amp + 1 for overlap with cnvkit
         assert sum(x.passed_filter for x in jumble_cnvs) == 1  # 1 amp
+
+    def test_cnv_sorting(self):
+        """
+        Make sure that numerical chromosome names are sorted properly.
+        """
+        cnvs = [
+            CNV(caller="cnvkit", chromosome="chr10", genes=[], start=100, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
+            CNV(caller="cnvkit", chromosome="chr2", genes=[], start=500, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
+            CNV(caller="cnvkit", chromosome="chr1", genes=[], start=500, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
+            CNV(caller="cnvkit", chromosome="chr1", genes=[], start=100, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
+        ]
+
+        sorted_cnvs = sort_cnvs(cnvs)
+
+        assert len(sorted_cnvs) == len(cnvs)
+        assert sorted_cnvs[0] == cnvs[3]
+        assert sorted_cnvs[1] == cnvs[2]
+        assert sorted_cnvs[2] == cnvs[1]
+        assert sorted_cnvs[3] == cnvs[0]

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -408,6 +408,7 @@ class TestMergeCnvJson(unittest.TestCase):
             CNV(caller="cnvkit", chromosome="chr2", genes=[], start=500, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
             CNV(caller="cnvkit", chromosome="chr1", genes=[], start=500, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
             CNV(caller="cnvkit", chromosome="chr1", genes=[], start=100, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
+            CNV(caller="cnvkit", chromosome="chrM", genes=[], start=100, length=200, cn=2, baf=0.5, type="COPY_NORMAL"),
         ]
 
         sorted_cnvs = sort_cnvs(cnvs)
@@ -417,3 +418,4 @@ class TestMergeCnvJson(unittest.TestCase):
         assert sorted_cnvs[1] == cnvs[2]
         assert sorted_cnvs[2] == cnvs[1]
         assert sorted_cnvs[3] == cnvs[0]
+        assert sorted_cnvs[4] == cnvs[4]

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -37,6 +37,9 @@ class CNV:
     def __hash__(self):
         return hash(f"{self.caller}_{self.chromosome}:{self.start}-{self.end()}_{self.cn}")
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
 
 def parse_fai(filename, skip=None):
     with open(filename) as f:

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -249,7 +249,9 @@ def merge_cnv_dicts(dicts, vaf, annotations, cytobands, chromosomes, filtered_cn
         for chrom in uf_cnvs.keys():
             merged_cnvs = filter_chr_cnvs(uf_cnvs[chrom], f_cnvs[chrom])
             for caller, m_cnvs in merged_cnvs.items():
-                cnvs[chrom]["callers"][caller]["cnvs"] = m_cnvs
+                for c in m_cnvs:
+                    if c not in cnvs[chrom]["callers"][caller]["cnvs"]:
+                        cnvs[chrom]["callers"][caller]["cnvs"].append(c)
 
     for d in dicts:
         for r in sorted(d["ratios"], key=lambda x: x["start"]):

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -201,7 +201,9 @@ def filter_chr_cnvs(unfiltered_cnvs: Dict[str, List[CNV]], filtered_cnvs: Dict[s
 
 def sort_cnvs(cnvs: List[CNV]) -> List[CNV]:
     def cnv_key_func(x):
-        chrom_id = x.chromosome.removeprefix("chr")
+        chrom_id = x.chromosome
+        if x.chromosome.startswith("chr"):
+            chrom_id = x.chromosome[3:]
         if chrom_id.isdigit():
             chrom_id = int(chrom_id)
         return [chrom_id, x.start]

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -199,6 +199,16 @@ def filter_chr_cnvs(unfiltered_cnvs: Dict[str, List[CNV]], filtered_cnvs: Dict[s
     return cnvs
 
 
+def sort_cnvs(cnvs: List[CNV]) -> List[CNV]:
+    def cnv_key_func(x):
+        chrom_id = x.chromosome.removeprefix("chr")
+        if chrom_id.isdigit():
+            chrom_id = int(chrom_id)
+        return [chrom_id, x.start]
+
+    return sorted(cnvs, key=cnv_key_func)
+
+
 def merge_cnv_calls(unfiltered_cnvs, filtered_cnvs):
     cnvs = []
     # Iterate over the filtered and unfiltered CNVs and pair them according to overlap.
@@ -209,7 +219,7 @@ def merge_cnv_calls(unfiltered_cnvs, filtered_cnvs):
                 for c in m_cnvs:
                     if c not in cnvs:
                         cnvs.append(c)
-    return cnvs
+    return sort_cnvs(cnvs)
 
 
 def merge_cnv_dicts(dicts, vaf, annotations, cytobands, chromosomes, filtered_cnvs, unfiltered_cnvs):

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -329,6 +329,13 @@ def main():
     if cytoband_file and show_cytobands:
         cytobands = parse_cytobands(cytoband_file, cytoband_colors, cytoband_centromere, skip_chromosomes)
 
+    if len(filtered_cnv_vcf_files) != len(cnv_vcf_files):
+        print(
+            f"error: the number of unfiltered vcf files ({len(filtered_cnv_vcf_files)}) "
+            f"must match the number of filtered vcf files ({len(cnv_vcf_files)})"
+        )
+        sys.exit(1)
+
     filtered_cnv_vcfs = []
     unfiltered_cnv_vcfs = []
     for f_vcf, uf_vcf in zip(filtered_cnv_vcf_files, cnv_vcf_files):

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -205,7 +205,7 @@ def sort_cnvs(cnvs: List[CNV]) -> List[CNV]:
         if x.chromosome.startswith("chr"):
             chrom_id = x.chromosome[3:]
         if chrom_id.isdigit():
-            chrom_id = int(chrom_id)
+            chrom_id = f"{int(chrom_id):0>5}"
         return [chrom_id, x.start]
 
     return sorted(cnvs, key=cnv_key_func)

--- a/workflow/templates/cnv_html_report/03-results-table.js
+++ b/workflow/templates/cnv_html_report/03-results-table.js
@@ -198,8 +198,10 @@ class ResultsTable extends EventTarget {
       )
       .flat();
 
+    let hasData = true;
+
     if (tableData.length === 0) {
-      tableData = [{ "No data to display": [] }];
+      hasData = false;
     } else {
       // Find the corresponding copy numbers from the other caller(s)
       for (let cnv of tableData) {
@@ -233,6 +235,17 @@ class ResultsTable extends EventTarget {
       .join("th")
       .text(this.columnLabel)
       .attr("class", (d) => this.columnDef(d).class);
+
+    this.#body.selectAll("tr").remove();
+
+    if (!hasData) {
+      this.#body
+        .append("tr")
+        .append("td")
+        .text("No data to display")
+        .attr("colspan", this.visibleColumns.length);
+      return;
+    }
 
     this.#body
       .selectAll("tr")


### PR DESCRIPTION
A bug was discovered where some very clear variants didn't show up in the results table of the CNV html report. It turned out to be happening when there were multiple sets of VCF files passed as input, and the files that were parsed later had variants for the same caller and chromosome as the previously parsed file. Very stupid mistake.

Part of the reason for this going undetected was that the integration test only included one set of VCF files. Now the integration test includes two sets.

This should be fixed with this PR. I took the opportunity to refactor some things in order to make things easier to test. I also added more unit tests in order to catch these types of issues.

In working on this, I also discovered that empty tables were presented incorrectly. This has also been addressed.