### PR TITLE
fix(cnv): address issue with identical CNVs being ignored

### DIFF
--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf
@@ -4,6 +4,8 @@
 ##contig=<ID=chrM>
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=CORR_CN,Number=1,Type=Float,Description="Corrected copy number">
+##INFO=<ID=BAF,Number=1,Type=Float,Description="B-allele frequency">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
 chrA	1100	.	N	<DUP>	.	.	Genes=gene1;SVTYPE=DUP;END=1400;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10
 chrA	3000	.	N	<DUP>	.	.	Genes=gene2;SVTYPE=DUP;END=4000;SVLEN=1000;BAF=0.3;CALLER=cnvkit;CORR_CN=10	GT:CN	0/1:10

--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf
@@ -4,6 +4,7 @@
 ##contig=<ID=chrM>
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
-##INFO=<ID=CORR_CN,Number=1,Type=Integer,Description="Corrected copy number">
+##INFO=<ID=CORR_CN,Number=1,Type=Float,Description="Corrected copy number">
+##INFO=<ID=BAF,Number=1,Type=Float,Description="B-allele frequency">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
 chrA	800	.	N	<DEL>	.	.	Genes=gene1;SVTYPE=DEL;END=1100;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=1	GT:CN	0/1:1

--- a/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.vcf
+++ b/.tests/integration/cnv_sv/svdb_query/sample1_T.pathology.svdb_query.annotate_cnv.cnv_loh_genes.vcf
@@ -4,6 +4,7 @@
 ##contig=<ID=chrM>
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
-##INFO=<ID=CORR_CN,Number=1,Type=Integer,Description="Corrected copy number">
+##INFO=<ID=CORR_CN,Number=1,Type=Float,Description="Corrected copy number">
+##INFO=<ID=BAF,Number=1,Type=Float,Description="B-allele frequency">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878_N
 chrA	800	.	N	<DEL>	.	.	Genes=gene1;SVTYPE=DEL;END=1100;SVLEN=300;BAF=0.3;CALLER=cnvkit;CORR_CN=1	GT:CN	0/1:1

--- a/.tests/unit/test_merge_cnv_json.py
+++ b/.tests/unit/test_merge_cnv_json.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from dataclasses import dataclass
 import os
 import sys
@@ -387,6 +388,8 @@ class TestMergeCnvJson(unittest.TestCase):
                     },
                 ],
                 filtered_cnvs=[
+                    # Filtered amplifications
+                    defaultdict(lambda: defaultdict(list)),
                     # Filtered deletions
                     {
                         "chr1": {
@@ -438,7 +441,7 @@ class TestMergeCnvJson(unittest.TestCase):
                         assert all([exp["genes"][i] for gene in c.genes])
 
                     n_pass_filter = sum(x.passed_filter for x in callerdata[0]["cnvs"])
-                    assert n_pass_filter == case.expected_cnvs[chromosome][caller]["pass_filter_count"]
+                    assert n_pass_filter == exp["pass_filter_count"]
 
     def test_merge_cnv_calls(self):
         unfiltered_files = [

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -221,6 +221,13 @@ def merge_cnv_calls(unfiltered_cnvs, filtered_cnvs):
                 for c in m_cnvs:
                     if c not in cnvs:
                         cnvs.append(c)
+                    else:
+                        # If it already exists, make sure that it represents
+                        # all genes and that the filtering status is updated
+                        added_cnv = cnvs.pop(cnvs.index(c))
+                        added_cnv.genes = list(set(added_cnv.genes + c.genes))
+                        added_cnv.passed_filter = added_cnv.passed_filter or c.passed_filter
+                        cnvs.append(added_cnv)
     return sort_cnvs(cnvs)
 
 

--- a/workflow/scripts/merge_cnv_json.py
+++ b/workflow/scripts/merge_cnv_json.py
@@ -35,7 +35,7 @@ class CNV:
         )
 
     def __hash__(self):
-        return hash(f"{self.caller}_{self.chromosome}:{self.start}-{self.end()}_{self.cn}")
+        return hash(f"{self.caller}_{self.chromosome}:{self.start}-{self.end()}_{self.cn:.2f}")
 
     def __eq__(self, other):
         return hash(self) == hash(other)


### PR DESCRIPTION
A bug was discovered where some CNVs were seemingly missing from the table in the final report. It turned out that they weren't strictly missing.

The issue occurs when there are identical CNVs in more than one set of VCF files, but the annotations differ. Since I wanted to avoid duplicate CNVs in the final table I ignored these before, but this didn't take the gene annotations into account.

This PR addresses this issue by merging the gene annotations for identical CNVs and also making sure that the filter status is correct.