### PR TITLE
fix: Cnv report table fix (showing wrong non-default caller in report table)

### DIFF
--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1016,11 +1016,18 @@ class ChromosomePlot extends EventTarget {
           const r = callerRatios[i];
           if (r.start >= d.start && r.end <= d.end) {
             count++;
-            if (count >= 3) break;
+            if (count >= 11) break;
           }
           if (r.start > d.end) break;
         }
-        return count >= 3;
+        if (count < 3) return false;
+        if (count < 11) {
+          const overlapsROI = this.#data.annotations.some(
+            (a) => a.start <= d.end && a.end >= d.start
+          );
+          if (!overlapsROI) return false;
+        }
+        return true;
       })
       .map((d) => {
         let ts = { ...d };

--- a/workflow/templates/cnv_html_report/01-chromosome-plot.js
+++ b/workflow/templates/cnv_html_report/01-chromosome-plot.js
@@ -1022,7 +1022,7 @@ class ChromosomePlot extends EventTarget {
         }
         if (count < 3) return false;
         if (count < 11) {
-          const overlapsROI = this.#data.annotations.some(
+          const overlapsROI = this.#data.annotations?.some(
             (a) => a.start <= d.end && a.end >= d.start
           );
           if (!overlapsROI) return false;

--- a/workflow/templates/cnv_html_report/03-results-table.js
+++ b/workflow/templates/cnv_html_report/03-results-table.js
@@ -37,7 +37,7 @@ class ResultsTable extends EventTarget {
     ];
 
     this.#data = config?.data;
-    this.#activeCaller = config?.caller ? config.caller : 0;
+    this.#activeCaller = config?.caller ?? 0;
 
     this.#tooltip = this.initTooltip();
 

--- a/workflow/templates/cnv_html_report/05-main.js
+++ b/workflow/templates/cnv_html_report/05-main.js
@@ -120,6 +120,7 @@ const genomePlot = new GenomePlot({
 
 const resultsTable = new ResultsTable(d3.select("#cnv-table"), {
   data: cnvData,
+  caller: initialCallerIndex !== -1 ? initialCallerIndex : 0,
   filter: d3.select("#table-filter-toggle").node().checked,
 });
 


### PR DESCRIPTION
Also improved out-of-range filtering of segments outside of regions of interest to decrease cluttering and faster interpretation of results.
